### PR TITLE
Allow disabling SSL certificates verification

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,13 +77,15 @@ Caching
 =======
 The default cache backed is SqliteCache.  It caches the WSDL and XSD files for 
 1 hour by default. You can disable caching by passing `None` as value to the
-`cache` attribute when initializing the client::
+`Transport.cache` attribute when initializing the client::
 
     >>> from zeep import Client
     >>> from zeep.cache import SqliteCache
+    >>> from zeep.transports import Transport
+    >>> transport = Transport(cache=None)
     >>> client = zeep.Client(
     ...     'http://www.webservicex.net/ConvertSpeed.asmx?WSDL', 
-    ...     cache=None)
+    ...     transport=transport)
 
 
 Changing the SqliteCache settings can be done via::
@@ -91,9 +93,27 @@ Changing the SqliteCache settings can be done via::
 
     >>> from zeep import Client
     >>> from zeep.cache import SqliteCache
+    >>> from zeep.transports import Transport
+    >>> cache = SqliteCache(persistent=True, timeout=60)
+    >>> transport = Transport(cache=cache)
     >>> client = zeep.Client(
     ...     'http://www.webservicex.net/ConvertSpeed.asmx?WSDL',
-    ...     cache=SqliteCache(persistent=True, timeout=60))
+    ...     transport=transport)
+
+
+Transport options
+=================
+If you need to change options like cache, timeout or ssl verification
+use `Transport` class.
+
+For instance to disable SSL verification use `verify` option::
+
+    >>> from zeep import Client
+    >>> from zeep.transports import Transport
+    >>> transport = Transport(verify=False)
+    >>> client = zeep.Client(
+    ...     'http://www.webservicex.net/ConvertSpeed.asmx?WSDL',
+    ...     transport=transport)
 
 
 Helpers

--- a/src/zeep/__main__.py
+++ b/src/zeep/__main__.py
@@ -8,6 +8,7 @@ import time
 
 from zeep.cache import SqliteCache
 from zeep.client import Client
+from zeep.transports import Transport
 
 logger = logging.getLogger('zeep')
 
@@ -57,8 +58,9 @@ def main(args):
         profile.enable()
 
     cache = SqliteCache(persistent=args.cache)
+    transport = Transport(cache=cache)
     st = time.time()
-    client = Client(args.wsdl_file, cache=cache)
+    client = Client(args.wsdl_file, transport=transport)
     logger.debug("Loading WSDL took %sms", (time.time() - st) * 1000)
 
     if args.profile:

--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -1,7 +1,6 @@
 import logging
 import warnings
 
-from zeep.cache import SqliteCache
 from zeep.transports import Transport
 from zeep.wsdl import WSDL
 
@@ -41,9 +40,8 @@ class ServiceProxy(object):
 
 class Client(object):
 
-    def __init__(self, wsdl, cache=None, wsse=None):
-        self.cache = cache or SqliteCache()
-        self.transport = Transport(self.cache)
+    def __init__(self, wsdl, wsse=None, transport=None):
+        self.transport = transport or Transport()
         self.wsdl = WSDL(wsdl, self.transport)
         self.wsse = wsse
 

--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -1,11 +1,14 @@
 import requests
 
+from zeep.cache import SqliteCache
+
 
 class Transport(object):
 
-    def __init__(self, cache=None, timeout=300):
-        self.cache = cache
+    def __init__(self, cache=None, timeout=300, verify=True):
+        self.cache = cache or SqliteCache()
         self.timeout = timeout
+        self.verify = verify
 
     def load(self, url):
         if self.cache:
@@ -13,7 +16,7 @@ class Transport(object):
             if response:
                 return bytes(response)
 
-        response = requests.get(url, timeout=self.timeout)
+        response = requests.get(url, timeout=self.timeout, verify=self.verify)
 
         if self.cache:
             self.cache.add(url, response.content)
@@ -21,5 +24,7 @@ class Transport(object):
         return response.content
 
     def post(self, address, message, headers):
-        response = requests.post(address, data=message, headers=headers)
+        response = requests.post(
+            address, data=message, headers=headers, verify=self.verify
+        )
         return response


### PR DESCRIPTION
Hi. It would be nice to have control over all `requests` params, but so far I cannot use `zeep` because of SSL verification.