### PR TITLE
Set name to __repr__ if no type name

### DIFF
--- a/src/zeep/xsd/elements.py
+++ b/src/zeep/xsd/elements.py
@@ -76,9 +76,13 @@ class Element(Base):
         return self.type(*args, **kwargs)
 
     def _signature(self, name):
+        if hasattr(self.type, 'name'):
+            typename = self.type.name
+        else:
+            typename = self.type.__repr__
         return '%s%s: %s%s' % (
             name, '=None' if self.is_optional else '',
-            self.type.name, '[]' if self.max_occurs != 1 else ''
+            typename, '[]' if self.max_occurs != 1 else ''
         )
 
 


### PR DESCRIPTION
* The name of the type maybe not set (in case of QName e.g.)

I am unsure if this is the correct way to fix #15 