### PR TITLE
fix SOAP 1.2 content type

### DIFF
--- a/src/zeep/wsdl/soap.py
+++ b/src/zeep/wsdl/soap.py
@@ -178,7 +178,7 @@ class Soap12Binding(SoapBinding):
         'wsdl': 'http://schemas.xmlsoap.org/wsdl/',
         'xsd': 'http://www.w3.org/2001/XMLSchema',
     }
-    content_type = 'application/xml+soap; charset=utf-8'
+    content_type = 'application/soap+xml; charset=utf-8'
 
 
 class SoapOperation(Operation):


### PR DESCRIPTION
Is there a reason for "content_type = 'application/xml+soap; charset=utf-8'"

Here https://www.w3.org/TR/soap12-part1/#reltoxml  I find only:

"application/soap+xml"