### PR TITLE
Use Header even if object does not have a header

### DIFF
--- a/src/zeep/wsdl/soap.py
+++ b/src/zeep/wsdl/soap.py
@@ -435,6 +435,9 @@ class DocumentMessage(SoapMessage):
                 header_value = header_obj(**header_value)
             header = soap.Header()
             header_obj.render(header, header_value)
+        else:
+            if header_value is not None:
+                header = soap.Header(header_value)
 
         headerfault = None
         return body, header, headerfault


### PR DESCRIPTION
* A Header needs to be created if there is not a header already in the
  Element. This was not covered by the old implementation
