### PR TITLE
Use Header even if object does not have a header

### DIFF
--- a/src/zeep/wsdl/messages.py
+++ b/src/zeep/wsdl/messages.py
@@ -76,6 +76,9 @@ class SoapMessage(ConcreteMessage):
                 header_value = self.header(**header_value)
             header = soap.Header()
             self.header.render(header, header_value)
+        else:
+            if header_value is not None:
+                header = soap.Header(header_value)
 
         envelope = soap.Envelope()
         if header is not None:


### PR DESCRIPTION
* A Header needs to be created if there is not a header already in the
  Element. This was not covered by the old implementation