### PR TITLE
Always store bytes in cache database

### DIFF
--- a/src/zeep/cache.py
+++ b/src/zeep/cache.py
@@ -6,7 +6,7 @@ import sqlite3
 
 
 class SqliteCache(object):
-    _version = b'1'
+    _version = '1'
 
     def __init__(self, persistent=True, path=None, timeout=3600):
         self._timeout = timeout
@@ -63,4 +63,5 @@ class SqliteCache(object):
 
     @property
     def _version_string(self):
-        return b'$ZEEP:%s$' % self._version
+        prefix = u'$ZEEP:%s$' % self._version
+        return bytes(prefix.encode('ascii'))

--- a/src/zeep/cache.py
+++ b/src/zeep/cache.py
@@ -1,11 +1,12 @@
 import base64
 import datetime
 import os
+import six
 import sqlite3
 
 
 class SqliteCache(object):
-    _version = '1'
+    _version = b'1'
 
     def __init__(self, persistent=True, path=None, timeout=3600):
         self._timeout = timeout
@@ -50,13 +51,16 @@ class SqliteCache(object):
 
     def _encode_data(self, data):
         data = base64.b64encode(data)
+        if six.PY2:
+            return buffer(self._version_string + data)
         return self._version_string + data
 
     def _decode_data(self, data):
+        if six.PY2:
+            data = str(data)
         if data.startswith(self._version_string):
             return base64.b64decode(data[len(self._version_string):])
 
     @property
     def _version_string(self):
-        prefix = u'$ZEEP:%s$' % self._version
-        return bytes(prefix.encode('ascii'))
+        return b'$ZEEP:%s$' % self._version


### PR DESCRIPTION
Failing to always store a consistent type in the database result in the cache
being unusable when using both python2 and python3 with the same database
(see #48).