### PR TITLE
Always enclude the EncodingType attribute in the Nonce element

### DIFF
--- a/src/zeep/wsse/username.py
+++ b/src/zeep/wsse/username.py
@@ -42,7 +42,8 @@ class UsernameToken(object):
         </wsse:Security>
 
     """
-    namespace = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0'  # noqa
+    username_token_profile_ns = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0'  # noqa
+    soap_message_secutity_ns = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0'    # noqa
 
     def __init__(self, username, password=None, password_digest=None,
                  use_digest=False, nonce=None, created=None):
@@ -82,7 +83,8 @@ class UsernameToken(object):
     def _create_password_text(self):
         return [
             WSSE.Password(
-                self.password, Type='%s#PasswordText' % self.namespace)
+                self.password,
+                Type='%s#PasswordText' % self.username_token_profile_ns)
         ]
 
     def _create_password_digest(self):
@@ -105,8 +107,12 @@ class UsernameToken(object):
 
         return [
             WSSE.Password(
-                digest, Type='%s#PasswordDigest' % self.namespace
+                digest,
+                Type='%s#PasswordDigest' % self.username_token_profile_ns
             ),
-            WSSE.Nonce(base64.b64encode(nonce).decode('utf-8')),
+            WSSE.Nonce(
+                base64.b64encode(nonce).decode('utf-8'),
+                EncodingType='%s#Base64Binary' % self.soap_message_secutity_ns
+            ),
             WSU.Created(timestamp)
         ]

--- a/tests/test_wsse_username.py
+++ b/tests/test_wsse_username.py
@@ -117,7 +117,7 @@ def test_password_digest(monkeypatch):
               <ns0:UsernameToken>
                 <ns0:Username>michael</ns0:Username>
                 <ns0:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">hVicspAQSg70JNhe67OHqD9gexc=</ns0:Password>
-                <ns0:Nonce>bW9ja2VkLXJhbmRvbQ==</ns0:Nonce>
+                <ns0:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">bW9ja2VkLXJhbmRvbQ==</ns0:Nonce>
                 <ns0:Created xmlns:ns0="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-05-08T12:00:00+00:00</ns0:Created>
               </ns0:UsernameToken>
             </ns0:Security>
@@ -171,7 +171,7 @@ def test_password_digest_custom(monkeypatch):
               <ns0:UsernameToken>
                 <ns0:Username>michael</ns0:Username>
                 <ns0:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">12345</ns0:Password>
-                <ns0:Nonce>aWV0cw==</ns0:Nonce>
+                <ns0:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">aWV0cw==</ns0:Nonce>
                 <ns0:Created xmlns:ns0="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-06-04T20:10:00+00:00</ns0:Created>
               </ns0:UsernameToken>
             </ns0:Security>


### PR DESCRIPTION
According to the specs [0] the attribute is optional and thus strictly speaking zeep is
correct.  However, according to this stackoverflow answer [1] and to my
experience, some Java Web Services don't work if you don't include the
EncodingType attribute.

[0] https://www.oasis-open.org/committees/download.php/16782/wss-v1.1-spec-os-UsernameTokenProfile.pdf
[1] http://stackoverflow.com/questions/7418506/how-do-i-add-an-encodingtype-attribute-to-the-nonce-element-of-a-usernametoken-i