### PR TITLE
Rename xsd.Schema to xsd.SchemaDocument and create one parent xsd.Schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /docs/_build/
 /frutsels/
 /server/
+/htmlcov/

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ retest:
 	py.test -vvv --lf
 
 coverage:
-	py.test --cov=zeep --cov-report=term-missing
+	py.test --cov=zeep --cov-report=term-missing --cov-report=html
 
 docs:
 	$(MAKE) -C docs html

--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -99,7 +99,7 @@ class Client(object):
         port.binding_options['address'] = address
 
     def get_type(self, name):
-        return self.wsdl.schema.get_type(name)
+        return self.wsdl.types.get_type(name)
 
     def get_element(self, name):
-        return self.wsdl.schema.get_element(name)
+        return self.wsdl.types.get_element(name)

--- a/src/zeep/parser.py
+++ b/src/zeep/parser.py
@@ -7,40 +7,20 @@ from six.moves.urllib.parse import urljoin, urlparse
 from zeep.exceptions import XMLSyntaxError
 
 
-class ImportResolver(etree.Resolver):
-    def __init__(self, transport, parser_context):
-        self.parser_context = parser_context
-        self.transport = transport
-
-    def resolve(self, url, pubid, context):
-        if url.startswith('intschema'):
-            text = etree.tostring(self.parser_context.schema_nodes.get(url))
-            return self.resolve_string(text, context)
-
-        if urlparse(url).scheme in ('http', 'https'):
-            content = self.transport.load(url)
-            return self.resolve_string(content, context)
-
-
-def parse_xml(content, transport, parser_context=None, base_url=None):
+def parse_xml(content, transport, base_url=None):
     parser = etree.XMLParser(remove_comments=True)
-    parser.resolvers.add(ImportResolver(transport, parser_context))
     try:
         return fromstring(content, parser=parser, base_url=base_url)
     except etree.XMLSyntaxError as exc:
         raise XMLSyntaxError("Invalid XML content received (%s)" % exc.message)
 
 
-def load_external(url, transport, parser_context=None, base_url=None):
-    if url.startswith('intschema'):
-        assert parser_context
-        return parser_context.schema_nodes.get(url)
-
+def load_external(url, transport, base_url=None):
     if base_url:
         url = absolute_location(url, base_url)
 
     response = transport.load(url)
-    return parse_xml(response, transport, parser_context, base_url)
+    return parse_xml(response, transport, base_url)
 
 
 def absolute_location(location, base):

--- a/src/zeep/wsdl/definitions.py
+++ b/src/zeep/wsdl/definitions.py
@@ -58,9 +58,9 @@ class AbstractMessage(object):
             part_type = qname_attr(part, 'type', tns)
 
             if part_element is not None:
-                part_element = definitions.schema.get_element(part_element)
+                part_element = definitions.types.get_element(part_element)
             if part_type is not None:
-                part_type = definitions.schema.get_type(part_type)
+                part_type = definitions.types.get_type(part_type)
 
             msg.add_part(part_name, MessagePart(part_element, part_type))
         return msg

--- a/src/zeep/wsdl/messages.py
+++ b/src/zeep/wsdl/messages.py
@@ -65,7 +65,7 @@ class SoapMessage(ConcreteMessage):
 
     def serialize(self, *args, **kwargs):
         nsmap = self.nsmap.copy()
-        nsmap.update(self.wsdl.schema._prefix_map)
+        nsmap.update(self.wsdl.types._prefix_map)
 
         soap = ElementMaker(namespace=self.nsmap['soap-env'], nsmap=nsmap)
         body = header = None
@@ -204,7 +204,7 @@ class DocumentMessage(SoapMessage):
         for part in self.abstract.parts.values():
             elm = node.find(part.element.qname)
             assert elm is not None, '%s not found' % part.element.qname
-            result.append(part.element.parse(elm, self.wsdl.schema))
+            result.append(part.element.parse(elm, self.wsdl.types))
 
         if len(result) > 1:
             return tuple(result)
@@ -231,7 +231,7 @@ class RpcMessage(SoapMessage):
 
     def deserialize(self, node):
         value = node.find(self.body.qname)
-        result = self.body.parse(value, self.wsdl.schema)
+        result = self.body.parse(value, self.wsdl.types)
 
         result = [
             getattr(result, field.name)
@@ -489,7 +489,7 @@ class MimeXML(MimeMessage):
     def deserialize(self, node):
         node = fromstring(node)
         part = self.abstract.parts.values()[0]
-        return part.element.parse(node, self.wsdl.schema)
+        return part.element.parse(node, self.wsdl.types)
 
     @classmethod
     def parse(cls, definitions, xmlelement, operation):

--- a/src/zeep/wsdl/wsdl.py
+++ b/src/zeep/wsdl/wsdl.py
@@ -321,8 +321,6 @@ class Definition(object):
                 if not location and namespace in schema_ns:
                     import_node.set('schemaLocation', schema_ns[namespace])
 
-                container.append(deepcopy(import_node))
-
         schema_node = container
         return Schema(
             schema_node, self.wsdl.transport, self.location,

--- a/src/zeep/wsdl/wsdl.py
+++ b/src/zeep/wsdl/wsdl.py
@@ -13,6 +13,7 @@ from zeep.utils import findall_multiple_ns
 from zeep.wsdl import definitions, http, soap
 from zeep.xsd import Schema
 from zeep.xsd.context import ParserContext
+from zeep.xsd.parser import parse_xml as xsd_parse_xml
 
 NSMAP = {
     'wsdl': 'http://schemas.xmlsoap.org/wsdl/',
@@ -62,7 +63,7 @@ class Document(object):
         root_definitions.resolve_imports()
 
         # Make the wsdl definitions public
-        self.schema = root_definitions.schema
+        self.types = root_definitions.types
         self.messages = root_definitions.messages
         self.port_types = root_definitions.port_types
         self.bindings = root_definitions.bindings
@@ -74,17 +75,17 @@ class Document(object):
     def dump(self):
         print('')
         print("Prefixes:")
-        for prefix, namespace in self.schema._prefix_map.items():
+        for prefix, namespace in self.types._prefix_map.items():
             print(' ' * 4, '%s: %s' % (prefix, namespace))
 
         print('')
         print("Global elements:")
-        for elm_obj in sorted(self.schema.elements, key=lambda k: six.text_type(k)):
+        for elm_obj in sorted(self.types.elements, key=lambda k: six.text_type(k)):
             print(' ' * 4, six.text_type(elm_obj))
 
         print('')
         print("Global types:")
-        for type_obj in sorted(self.schema.types, key=lambda k: six.text_type(k)):
+        for type_obj in sorted(self.types.types, key=lambda k: six.text_type(k)):
             print(' ' * 4, six.text_type(type_obj))
 
         print('')
@@ -111,21 +112,8 @@ class Document(object):
 
         """
         if hasattr(location, 'read'):
-            return self._parse_content(location.read())
-        return load_external(
-            location, self.transport, self._parser_context, self.location)
-
-    def _parse_content(self, content, base_url=None):
-        """Parse the content as XML and return the document.
-
-        :param content: content to parse as XML
-        :param content: string, file
-        :param base_url: base url for loading referenced documents
-        :param base_url: string
-
-        """
-        return parse_xml(
-            content, self.transport, self._parser_context, base_url)
+            return parse_xml(location.read(), self.transport)
+        return load_external(location, self.transport, self.location)
 
 
 class Definition(object):
@@ -135,7 +123,7 @@ class Definition(object):
         self.wsdl = wsdl
         self.location = location
 
-        self.schema = None
+        self.types = None
         self.port_types = {}
         self.messages = {}
         self.bindings = {}
@@ -151,7 +139,7 @@ class Definition(object):
         # Process the definitions
         self.parse_imports(doc)
 
-        self.schema = self.parse_types(doc)
+        self.types = self.parse_types(doc)
         self.messages = self.parse_messages(doc)
         self.port_types = self.parse_ports(doc)
         self.bindings = self.parse_binding(doc)
@@ -179,20 +167,21 @@ class Definition(object):
             return
         self._resolved_imports = True
 
-        # Create a reference to an imported schema if the definition has no
-        # schema of it's own.
-        if self.schema is None:
+        # Create a reference to an imported types definition if the
+        # definition has no types of it's own.
+        if self.types is None or self.types.is_empty:
             for definition in self.imports.values():
-                if definition.schema and not definition.schema.is_empty:
-                    self.schema = definition.schema
+                if definition.types and not definition.types.is_empty:
+                    self.types = definition.types
                     break
             else:
-                logger.debug(
-                    "No suitable main schema found for wsdl. " +
-                    "Creating an empty placeholder")
-                self.schema = Schema(
-                    None, self.wsdl.transport, self.location,
-                    self.wsdl._parser_context, self.location)
+                if self.types is None:
+                    logger.debug(
+                        "No suitable main schema found for wsdl. " +
+                        "Creating an empty placeholder")
+                    self.types = Schema(
+                        None, self.wsdl, self.location,
+                        self.wsdl._parser_context)
 
         for definition in self.imports.values():
             definition.resolve_imports()
@@ -238,16 +227,20 @@ class Definition(object):
                 if etree.QName(document.tag).localname == 'schema':
                     self.schema = Schema(
                         document, self.wsdl.transport, location,
-                        self.wsdl._parser_context, location)
+                        self.wsdl._parser_context)
                 else:
                     wsdl = Definition(self.wsdl, document, location)
                     self.imports[namespace] = wsdl
 
     def parse_types(self, doc):
-        """Return a `types.Schema` instance.
+        """Return an xsd.Schema() instance for the given wsdl:types element.
 
-        Note that a WSDL can contain multiple XSD schema's. The schemas can
-        reference each other using xsd:import statements.
+        If the wsdl:types contain multiple schema definitions then a new
+        wrapping xsd.Schema is defined with xsd:import statements linking them
+        together.
+
+        If the wsdl:types doesn't container an xml schema then an empty schema
+        is returned instead.
 
             <definitions .... >
                 <types>
@@ -260,31 +253,35 @@ class Definition(object):
 
         """
         namespace_sets = [
-            {'xsd': 'http://www.w3.org/2001/XMLSchema'},
-            {'xsd': 'http://www.w3.org/1999/XMLSchema'},
+            {
+                'xsd': 'http://www.w3.org/2001/XMLSchema',
+                'wsdl': 'http://schemas.xmlsoap.org/wsdl/',
+            },
+            {
+                'xsd': 'http://www.w3.org/1999/XMLSchema',
+                'wsdl': 'http://schemas.xmlsoap.org/wsdl/',
+            },
         ]
 
         # Find xsd:schema elements (wsdl:types/xsd:schema)
-        types = doc.find('wsdl:types', namespaces=NSMAP)
-        if types is None or len(types) == 0:
-            schema_nodes = []
-        else:
-            schema_nodes = findall_multiple_ns(
-                types, 'xsd:schema', namespace_sets)
+        schema_nodes = findall_multiple_ns(
+            doc, 'wsdl:types/xsd:schema', namespace_sets)
 
         if not schema_nodes:
-            return None
+            return Schema(
+                None, self.wsdl.transport, self.location,
+                self.wsdl._parser_context)
 
         # FIXME: This fixes `test_parse_types_nsmap_issues`, lame solution...
         schema_nodes = [
-            self.wsdl._parse_content(etree.tostring(schema_node), self.location)
+            xsd_parse_xml(etree.tostring(schema_node), self.location)
             for schema_node in schema_nodes
         ]
 
         if len(schema_nodes) == 1:
             return Schema(
                 schema_nodes[0], self.wsdl.transport, self.location,
-                self.wsdl._parser_context, self.location)
+                self.wsdl._parser_context)
 
         # A wsdl can contain multiple schema nodes. These can import each other
         # by simply referencing them by the namespace. To handle this in a way
@@ -306,6 +303,7 @@ class Definition(object):
         # Create a new schema node with xsd:import statements for all
         # schema's listed here.
         container = etree.Element('{http://www.w3.org/2001/XMLSchema}schema')
+        container.set('targetNamespace', 'http://www.python-zeep.org/Imports')
         for i, schema_node in enumerate(schema_nodes):
 
             # Create a new xsd:import element to import the schema
@@ -328,7 +326,7 @@ class Definition(object):
         schema_node = container
         return Schema(
             schema_node, self.wsdl.transport, self.location,
-            self.wsdl._parser_context, self.location)
+            self.wsdl._parser_context)
 
     def parse_messages(self, doc):
         """

--- a/src/zeep/xsd/context.py
+++ b/src/zeep/xsd/context.py
@@ -1,4 +1,5 @@
 class SchemaRepository(object):
+    """Mapping between schema location and schema object"""
     def __init__(self):
         self._schemas = {}
 
@@ -15,7 +16,7 @@ class SchemaRepository(object):
 
 
 class SchemaNodeRepository(object):
-
+    """Mapping between schema namespace and lxml node"""
     def __init__(self):
         self._nodes = {}
 
@@ -33,4 +34,6 @@ class ParserContext(object):
     def __init__(self):
         self.schema_nodes = SchemaNodeRepository()
         self.schema_objects = SchemaRepository()
+
+        # Mapping between internal nodes and original location
         self.schema_locations = {}

--- a/src/zeep/xsd/parser.py
+++ b/src/zeep/xsd/parser.py
@@ -1,0 +1,42 @@
+from defusedxml.lxml import fromstring
+from lxml import etree
+from six.moves.urllib.parse import urlparse
+
+from zeep.exceptions import XMLSyntaxError
+from zeep.parser import absolute_location
+
+
+class ImportResolver(etree.Resolver):
+    def __init__(self, transport, parser_context):
+        self.parser_context = parser_context
+        self.transport = transport
+
+    def resolve(self, url, pubid, context):
+        if url.startswith('intschema'):
+            text = etree.tostring(self.parser_context.schema_nodes.get(url))
+            return self.resolve_string(text, context)
+
+        if urlparse(url).scheme in ('http', 'https'):
+            content = self.transport.load(url)
+            return self.resolve_string(content, context)
+
+
+def parse_xml(content, transport, parser_context=None, base_url=None):
+    parser = etree.XMLParser(remove_comments=True)
+    parser.resolvers.add(ImportResolver(transport, parser_context))
+    try:
+        return fromstring(content, parser=parser, base_url=base_url)
+    except etree.XMLSyntaxError as exc:
+        raise XMLSyntaxError("Invalid XML content received (%s)" % exc.message)
+
+
+def load_external(url, transport, parser_context=None, base_url=None):
+    if url.startswith('intschema'):
+        assert parser_context
+        return parser_context.schema_nodes.get(url)
+
+    if base_url:
+        url = absolute_location(url, base_url)
+
+    response = transport.load(url)
+    return parse_xml(response, transport, parser_context, base_url)

--- a/src/zeep/xsd/schema.py
+++ b/src/zeep/xsd/schema.py
@@ -11,10 +11,106 @@ logger = logging.getLogger(__name__)
 
 
 class Schema(object):
+    """A schema is a collection of schema documents."""
 
+    def __init__(self, node=None, transport=None, location=None,
+                 parser_context=None):
+        self._parser_context = parser_context or ParserContext()
+        self._root = SchemaDocument(
+            node, transport, location, self._parser_context, location)
+
+        self._root.resolve()
+
+        def _collect_imports_recursive(schema, target=None):
+            if target is None:
+                target = OrderedDict()
+
+            target[schema._target_namespace] = schema
+            for ns, s in schema._imports.items():
+                if ns not in target:
+                    _collect_imports_recursive(s, target)
+            return target
+
+        self._schemas = _collect_imports_recursive(self._root)
+        self._prefix_map = self._create_prefix_map()
+
+    def __repr__(self):
+        return '<Schema(location=%r)>' % (self._root._location)
+
+    @property
+    def is_empty(self):
+        return self._root.is_empty
+
+    @property
+    def elements(self):
+        for schema in self._schemas.values():
+            for element in schema._elements.values():
+                yield element
+
+    @property
+    def types(self):
+        for schema in self._schemas.values():
+            for type_ in schema._types.values():
+                yield type_
+
+    def get_element(self, qname):
+        qname = self._create_qname(qname)
+        schema = self._get_schema_document(qname.namespace)
+        try:
+            return schema._elements[qname]
+        except KeyError:
+            known_elements = ', '.join(schema._elements.keys())
+            raise KeyError(
+                "No element '%s' in namespace %s. Available elements are: %s" % (
+                    qname.localname, qname.namespace, known_elements or ' - '))
+
+    def get_type(self, qname):
+        qname = self._create_qname(qname)
+
+        if qname.text in xsd_builtins.default_types:
+            return xsd_builtins.default_types[qname]
+
+        schema = self._get_schema_document(qname.namespace)
+        try:
+            return schema._types[qname]
+        except KeyError:
+            known_types = ', '.join(schema._types.keys())
+            raise KeyError(
+                "No type '%s' in namespace %s. Available types are: %s" % (
+                    qname.localname, qname.namespace, known_types or ' - '))
+
+    def _create_qname(self, name):
+        if isinstance(name, etree.QName):
+            return name
+
+        if not name.startswith('{') and ':' in name and self._prefix_map:
+            prefix, localname = name.split(':', 1)
+            if prefix in self._prefix_map:
+                return etree.QName(self._prefix_map[prefix], localname)
+            else:
+                raise ValueError(
+                    "No namespace defined for the prefix %r" % prefix)
+        else:
+            return etree.QName(name)
+
+    def _create_prefix_map(self):
+        prefix_map = {}
+        for i, namespace in enumerate(self._schemas.keys()):
+            prefix_map['ns%d' % i] = namespace
+        return prefix_map
+
+    def _get_schema_document(self, namespace):
+        if namespace not in self._schemas:
+            raise ValueError(
+                "No schema available for the namespace %r" % namespace)
+        return self._schemas[namespace]
+
+
+class SchemaDocument(object):
     def __init__(self, node=None, transport=None, location=None,
                  parser_context=None, base_url=None):
         logger.debug("Init schema for %r", location)
+        assert parser_context
 
         # Internal
         self._base_url = base_url or location
@@ -26,16 +122,11 @@ class Schema(object):
         self._elements = {}
         self._attributes = {}
         self._imports = OrderedDict()
-        self._prefix_map = {}
         self._xml_schema = None
         self._element_form = 'unqualified'
         self._attribute_form = 'unqualified'
+        self._resolved = False
 
-        is_root_schema = False
-        if not parser_context:
-            parser_context = ParserContext()
-        if not parser_context.schema_objects:
-            is_root_schema = True
         parser_context.schema_objects.add(self)
 
         if node is not None:
@@ -46,43 +137,19 @@ class Schema(object):
             visitor = SchemaVisitor(self, parser_context)
             visitor.visit_schema(node)
 
-        if is_root_schema:
-            for schema in self._imports.values():
-                schema.resolve()
-            self.resolve()
-            self._prefix_map = self.create_prefix_map()
-
-    def create_prefix_map(self):
-        logger.debug("Creating prefix map on %r", self)
-        assigned = set()
-        prefix_map = {}
-
-        if self._target_namespace:
-            prefix_map['ns0'] = self._target_namespace
-            assigned.add(self)
-
-        def _recurse(parent):
-            todo = []
-            for schema in parent._imports.values():
-                if schema._target_namespace and schema not in assigned:
-                    num = len(assigned)
-                    todo.append(schema)
-                    assigned.add(schema)
-                    if schema._target_namespace:
-                        prefix_map['ns%d' % num] = schema._target_namespace
-
-            for schema in todo:
-                _recurse(schema)
-
-        _recurse(self)
-        return prefix_map
-
     def __repr__(self):
-        return '<Schema(location=%r, tns=%s, is_empty=%r)>' % (
+        return '<SchemaDocument(location=%r, tns=%s, is_empty=%r)>' % (
             self._location, self._target_namespace, self.is_empty)
 
     def resolve(self):
-        logger.info("Resolving types in schema %s", self)
+        logger.info("Resolving in schema %s", self)
+
+        if self._resolved:
+            return
+        self._resolved = True
+
+        for schema in self._imports.values():
+            schema.resolve()
 
         for key, type_ in self._types.items():
             new = type_.resolve()
@@ -119,6 +186,8 @@ class Schema(object):
         if name.text in xsd_builtins.default_types:
             return xsd_builtins.default_types[name]
 
+        self._check_namespace_reference(name)
+
         if name.text in self._types:
             return self._types[name]
 
@@ -131,6 +200,8 @@ class Schema(object):
 
     def get_element(self, name):
         name = self._create_qname(name)
+        self._check_namespace_reference(name)
+
         if name in self._elements:
             return self._elements[name]
 
@@ -153,41 +224,20 @@ class Schema(object):
             "No such attribute: %r (Only have %s) (from: %s)" % (
                 name.text, ', '.join(self._attributes), self))
 
+    def _check_namespace_reference(self, name):
+        """See https://www.w3.org/TR/xmlschema-1/#src-resolve"""
+        ns = name.namespace
+
+        if ns != self._target_namespace and ns not in self._imports.keys():
+            raise ValueError((
+                "References from this schema (%r) to components in the " +
+                "namespace '%s' are not allowed, since not indicated by an "
+                "import statement."
+            ) % (self._target_namespace, ns))
+
     def _create_qname(self, name):
-        if isinstance(name, etree.QName):
-            return name
-
-        if not name.startswith('{') and ':' in name and self._prefix_map:
-            prefix, localname = name.split(':', 1)
-            if prefix in self._prefix_map:
-                return etree.QName(self._prefix_map[prefix], localname)
-            else:
-                raise ValueError(
-                    "No namespace defined for the prefix %r" % prefix)
-        else:
-            return etree.QName(name)
-
-    @property
-    def elements(self):
-        for value in self._elements.values():
-            yield value
-
-        for schema in self._imports.values():
-            for value in schema._elements.values():
-                yield value
-
-    @property
-    def types(self):
-        for value in self._types.values():
-            yield value
-
-        for schema in self._imports.values():
-            for value in schema._types.values():
-                yield value
+        return etree.QName(name) if not isinstance(name, etree.QName) else name
 
     @property
     def is_empty(self):
         return not bool(self._imports or self._types or self._elements)
-
-    def custom_type(self, name):
-        return self.get_type(name)

--- a/src/zeep/xsd/types.py
+++ b/src/zeep/xsd/types.py
@@ -1,12 +1,9 @@
-import itertools
-
 from collections import OrderedDict
 
 import six
 
 from zeep.xsd.elements import (
-    Any, Attribute, Choice, Element, GroupElement, ListElement, RefElement,
-    Sequence)
+    Any, Attribute, Choice, Element, GroupElement, ListElement, RefElement)
 from zeep.xsd.valueobjects import CompoundValue
 
 

--- a/src/zeep/xsd/visitor.py
+++ b/src/zeep/xsd/visitor.py
@@ -3,11 +3,12 @@ import logging
 
 from lxml import etree
 
-from zeep.parser import absolute_location, load_external
+from zeep.parser import absolute_location
 from zeep.utils import as_qname, qname_attr
 from zeep.xsd import builtins as xsd_builtins
 from zeep.xsd import elements as xsd_elements
 from zeep.xsd import types as xsd_types
+from zeep.xsd.parser import load_external
 
 logger = logging.getLogger(__name__)
 
@@ -113,10 +114,13 @@ class SchemaVisitor(object):
         if not location:
             if namespace:
                 location = namespace
-                schema_node = self.parser_context.schema_nodes.get(namespace)
+                try:
+                    schema_node = self.parser_context.schema_nodes.get(namespace)
+                except KeyError:
+                    raise ValueError("No schema for namespace=%s" % namespace)
 
             if not schema_node:
-                raise NotImplementedError("schemaLocation is required")
+                raise ValueError("schemaLocation is required")
 
         # If a schemaLocation is defined then make the location absolute based
         # on the base url and see if the schema is already processed (for

--- a/tests/test_wsdl.py
+++ b/tests/test_wsdl.py
@@ -38,9 +38,9 @@ def test_parse_soap_wsdl():
 
     with requests_mock.mock() as m:
         m.post('http://example.com/stockquote', text=response)
-        account = obj.schema.get_type('{http://example.com/stockquote.xsd}account')
+        account = obj.types.get_type('{http://example.com/stockquote.xsd}account')
         account.id = 100
-        country = obj.schema.get_element(
+        country = obj.types.get_element(
             '{http://example.com/stockquote.xsd}country'
         ).type()
         country.name = 'The Netherlands'
@@ -223,7 +223,7 @@ def test_parse_soap_import_wsdl():
     obj = wsdl.Document(
         'tests/wsdl_files/soap_import_main.wsdl', transport=client.transport)
     assert len(obj.services) == 1
-    assert obj.schema.is_empty is False
+    assert obj.types.is_empty is False
     obj.dump()
 
 
@@ -288,5 +288,5 @@ def test_multiple_extension():
     """.strip())
     document = wsdl.Document(content, None)
 
-    type_a = document.schema.get_type('ns0:type_a')
+    type_a = document.types.get_type('ns1:type_a')
     type_a(wat='x')

--- a/tests/test_wsdl_messages.py
+++ b/tests/test_wsdl_messages.py
@@ -160,7 +160,7 @@ def test_document_message_parse_with_header_other_message():
 
 
 def test_document_message_serializer():
-    wsdl = stub(schema=stub(_prefix_map={}))
+    wsdl = stub(types=stub(_prefix_map={}))
     operation = stub(soapaction='my-action')
     msg = messages.DocumentMessage(
         wsdl=wsdl,
@@ -202,7 +202,7 @@ def test_document_message_serializer():
 
 
 def test_document_message_serializer_header():
-    wsdl = stub(schema=stub(_prefix_map={}))
+    wsdl = stub(types=stub(_prefix_map={}))
     operation = stub(soapaction='my-action')
     msg = messages.DocumentMessage(
         wsdl=wsdl,
@@ -255,7 +255,7 @@ def test_document_message_serializer_header():
 
 
 def test_document_message_serializer_header_custom_elm():
-    wsdl = stub(schema=stub(_prefix_map={}))
+    wsdl = stub(types=stub(_prefix_map={}))
     operation = stub(soapaction='my-action', name='something')
     msg = messages.DocumentMessage(
         wsdl=wsdl,
@@ -310,7 +310,7 @@ def test_document_message_serializer_header_custom_elm():
 
 
 def test_document_message_serializer_header_custom_xml():
-    wsdl = stub(schema=stub(_prefix_map={}))
+    wsdl = stub(types=stub(_prefix_map={}))
     operation = stub(soapaction='my-action')
     msg = messages.DocumentMessage(
         wsdl=wsdl,
@@ -374,7 +374,7 @@ def test_document_message_deserializer():
           </mns:response>
         </SOAP-ENV:Body>
     """)  # noqa
-    wsdl = stub(schema=stub(_prefix_map={}))
+    wsdl = stub(types=stub(_prefix_map={}))
     operation = stub(soapaction='my-action', name='something')
 
     msg = messages.DocumentMessage(
@@ -449,7 +449,7 @@ def test_rpc_message_parse():
 
 
 def test_rpc_message_serializer(abstract_message_input):
-    wsdl = stub(schema=stub(_prefix_map={}))
+    wsdl = stub(types=stub(_prefix_map={}))
     operation = stub(soapaction='my-action', name='Operation')
 
     msg = messages.RpcMessage(
@@ -495,7 +495,7 @@ def test_rpc_message_deserializer(abstract_message_output):
           </mns:Response>
         </SOAP-ENV:Body>
     """)  # noqa
-    wsdl = stub(schema=stub(_prefix_map={}))
+    wsdl = stub(types=stub(_prefix_map={}))
     operation = stub(soapaction='my-action', name='something')
 
     msg = messages.RpcMessage(
@@ -516,7 +516,7 @@ def test_rpc_message_deserializer(abstract_message_output):
 
 
 def test_rpc_message_signature(abstract_message_input):
-    wsdl = stub(schema=stub(_prefix_map={}))
+    wsdl = stub(types=stub(_prefix_map={}))
     operation = stub(soapaction='my-action', name='something')
 
     msg = messages.RpcMessage(
@@ -533,7 +533,7 @@ def test_rpc_message_signature(abstract_message_input):
 
 
 def test_rpc_message_signature_output(abstract_message_output):
-    wsdl = stub(schema=stub(_prefix_map={}))
+    wsdl = stub(types=stub(_prefix_map={}))
     operation = stub(soapaction='my-action')
 
     msg = messages.RpcMessage(
@@ -553,7 +553,7 @@ def test_rpc_message_signature_output(abstract_message_output):
 # URLEncoded Message
 #
 def test_urlencoded_serialize(abstract_message_input):
-    wsdl = stub(schema=stub(_prefix_map={}))
+    wsdl = stub(types=stub(_prefix_map={}))
     operation = stub(location='my-action', name='foo')
 
     msg = messages.UrlEncoded(
@@ -573,7 +573,7 @@ def test_urlencoded_serialize(abstract_message_input):
 
 
 def test_urlencoded_signature(abstract_message_input):
-    wsdl = stub(schema=stub(_prefix_map={}))
+    wsdl = stub(types=stub(_prefix_map={}))
     operation = stub(location='my-action', name='foo')
 
     msg = messages.UrlEncoded(
@@ -592,7 +592,7 @@ def test_urlencoded_signature(abstract_message_input):
 # URLReplacement Message
 #
 def test_urlreplacement_serialize(abstract_message_input):
-    wsdl = stub(schema=stub(_prefix_map={}))
+    wsdl = stub(types=stub(_prefix_map={}))
     operation = stub(location='my-action/(arg1)/(arg2)/', name='foo')
 
     msg = messages.UrlReplacement(
@@ -612,7 +612,7 @@ def test_urlreplacement_serialize(abstract_message_input):
 
 
 def test_urlreplacement_signature(abstract_message_input):
-    wsdl = stub(schema=stub(_prefix_map={}))
+    wsdl = stub(types=stub(_prefix_map={}))
     operation = stub(location='my-action/(arg1)/(arg2)/', name='foo')
 
     msg = messages.UrlReplacement(
@@ -631,7 +631,7 @@ def test_urlreplacement_signature(abstract_message_input):
 # MimeContent Message
 #
 def test_mime_content_serialize_form_urlencoded(abstract_message_input):
-    wsdl = stub(schema=stub(_prefix_map={}))
+    wsdl = stub(types=stub(_prefix_map={}))
     operation = stub(location='my-action', name='foo')
 
     msg = messages.MimeContent(
@@ -655,7 +655,7 @@ def test_mime_content_serialize_form_urlencoded(abstract_message_input):
 
 
 def test_mime_content_serialize_xml():
-    wsdl = stub(schema=stub(_prefix_map={}))
+    wsdl = stub(types=stub(_prefix_map={}))
     operation = stub(location='my-action', name='foo')
 
     element_1 = xsd.Element('arg1', xsd.ComplexType([
@@ -692,7 +692,7 @@ def test_mime_content_serialize_xml():
 
 
 def test_mime_content_signature(abstract_message_input):
-    wsdl = stub(schema=stub(_prefix_map={}))
+    wsdl = stub(types=stub(_prefix_map={}))
     operation = stub(location='my-action', name='foo')
 
     msg = messages.MimeContent(

--- a/tests/test_xsd_integration.py
+++ b/tests/test_xsd_integration.py
@@ -803,7 +803,6 @@ def test_ref_attribute():
     assert_nodes_equal(expected, node)
 
 
-
 def test_init_with_dicts():
     node = etree.fromstring("""
         <?xml version="1.0"?>

--- a/tests/test_xsd_integration.py
+++ b/tests/test_xsd_integration.py
@@ -765,6 +765,45 @@ def test_qualified_attribute():
     assert_nodes_equal(expected, node)
 
 
+def test_ref_attribute():
+    node = etree.fromstring("""
+        <?xml version="1.0"?>
+        <xsd:schema
+                xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                xmlns:tns="http://tests.python-zeep.org/"
+                attributeFormDefault="qualified"
+                elementFormDefault="qualified"
+                targetNamespace="http://tests.python-zeep.org/">
+          <xsd:element name="Address">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="foo" type="xsd:string" form="unqualified" />
+              </xsd:sequence>
+              <xsd:attribute ref="tns:id" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:attribute name="id" type="xsd:string" use="required" />
+        </xsd:schema>
+    """.strip())
+
+    schema = xsd.Schema(node)
+    address_type = schema.get_element('{http://tests.python-zeep.org/}Address')
+    obj = address_type(foo='bar', id="hoi")
+
+    expected = """
+      <document>
+        <ns0:Address xmlns:ns0="http://tests.python-zeep.org/" ns0:id="hoi">
+          <foo>bar</foo>
+        </ns0:Address>
+      </document>
+    """
+
+    node = etree.Element('document')
+    address_type.render(node, obj)
+    assert_nodes_equal(expected, node)
+
+
+
 def test_init_with_dicts():
     node = etree.fromstring("""
         <?xml version="1.0"?>

--- a/tests/test_xsd_parse.py
+++ b/tests/test_xsd_parse.py
@@ -171,7 +171,13 @@ def test_parse_anytype_obj():
     )
 
     parser_context = ParserContext()
-    schema = SchemaDocument(parser_context=parser_context)
+    schema = SchemaDocument(
+        etree.Element('{http://www.w3.org/2001/XMLSchema}Schema'),
+        transport=None,
+        location=None,
+        parser_context=parser_context,
+        base_url=None)
+
     schema._target_namespace = 'http://tests.python-zeep.org/'
     schema.register_type('{http://tests.python-zeep.org/}something', value_type)
 

--- a/tests/test_xsd_parse.py
+++ b/tests/test_xsd_parse.py
@@ -2,6 +2,8 @@ from lxml import etree
 
 from tests.utils import load_xml
 from zeep import xsd
+from zeep.xsd.context import ParserContext
+from zeep.xsd.schema import SchemaDocument
 
 
 def test_parse_basic():
@@ -168,7 +170,9 @@ def test_parse_anytype_obj():
         ]
     )
 
-    schema = xsd.Schema()
+    parser_context = ParserContext()
+    schema = SchemaDocument(parser_context=parser_context)
+    schema._target_namespace = 'http://tests.python-zeep.org/'
     schema.register_type('{http://tests.python-zeep.org/}something', value_type)
 
     custom_type = xsd.Element(

--- a/tests/test_xsd_schemas.py
+++ b/tests/test_xsd_schemas.py
@@ -87,3 +87,66 @@ def test_multiple_extension():
     schema = xsd.Schema(node_a, transport=transport)
     type_a = schema.get_type('ns0:type_a')
     type_a(wat='x')
+
+
+def test_global_element_and_type():
+    node_a = etree.fromstring("""
+        <?xml version="1.0"?>
+        <xs:schema
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://tests.python-zeep.org/a"
+            targetNamespace="http://tests.python-zeep.org/a"
+            xmlns:b="http://tests.python-zeep.org/b"
+            elementFormDefault="qualified">
+
+            <xs:import
+                schemaLocation="http://tests.python-zeep.org/b.xsd"
+                namespace="http://tests.python-zeep.org/b"/>
+
+        </xs:schema>
+    """.strip())
+
+    node_b = etree.fromstring("""
+        <?xml version="1.0"?>
+        <xs:schema
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://tests.python-zeep.org/b"
+            targetNamespace="http://tests.python-zeep.org/b"
+            xmlns:c="http://tests.python-zeep.org/c"
+            elementFormDefault="qualified">
+
+            <xs:import
+                schemaLocation="http://tests.python-zeep.org/c.xsd"
+                namespace="http://tests.python-zeep.org/c"/>
+
+        </xs:schema>
+    """.strip())
+
+    node_c = etree.fromstring("""
+        <?xml version="1.0"?>
+        <xs:schema
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://tests.python-zeep.org/c"
+            targetNamespace="http://tests.python-zeep.org/c"
+            elementFormDefault="qualified">
+
+            <xs:complexType name="type_a">
+              <xs:sequence>
+                <xs:element name="item_a" type="xs:string"/>
+              </xs:sequence>
+            </xs:complexType>
+            <xs:element name="item" type="xs:string"/>
+        </xs:schema>
+    """.strip())
+    etree.XMLSchema(node_c)
+
+    transport = DummyTransport()
+    transport.bind('http://tests.python-zeep.org/b.xsd', node_b)
+    transport.bind('http://tests.python-zeep.org/c.xsd', node_c)
+
+    schema = xsd.Schema(node_a, transport=transport)
+    type_a = schema.get_type('{http://tests.python-zeep.org/c}type_a')
+    type_a(item_a='x')
+
+    elm = schema.get_element('{http://tests.python-zeep.org/c}item')
+    elm('x')

--- a/tests/test_xsd_visitor.py
+++ b/tests/test_xsd_visitor.py
@@ -4,13 +4,15 @@ from lxml import etree
 from tests.utils import assert_nodes_equal, load_xml, render_node
 from zeep import xsd
 from zeep.xsd import ListElement, builtins, visitor
-from zeep.xsd.schema import Schema
+from zeep.xsd.context import ParserContext
+from zeep.xsd.schema import SchemaDocument
 from zeep.xsd.types import UnresolvedType
 
 
 @pytest.fixture
 def schema_visitor():
-    schema = Schema()
+    parser_context = ParserContext()
+    schema = SchemaDocument(parser_context=parser_context)
     return visitor.SchemaVisitor(schema)
 
 
@@ -334,18 +336,17 @@ def test_complex_content_extension(schema_visitor):
     """)
     schema_visitor.visit_schema(node)
     schema = schema_visitor.schema
-    schema._prefix_map['ns0'] = 'http://tests.python-zeep.org/'
 
-    record_type = schema.get_type('ns0:SubType1')
+    record_type = schema.get_type('{http://tests.python-zeep.org/}SubType1')
     child_attrs = [child.name for child in record_type._children]
     assert len(child_attrs) == 3
 
-    record_type = schema.get_type('ns0:SubType2')
+    record_type = schema.get_type('{http://tests.python-zeep.org/}SubType2')
     child_attrs = [child.name for child in record_type._children]
     assert len(child_attrs) == 4
 
-    xsd_element = schema.get_element('ns0:test')
-    xsd_type = schema.get_type('ns0:SubType2')
+    xsd_element = schema.get_element('{http://tests.python-zeep.org/}test')
+    xsd_type = schema.get_type('{http://tests.python-zeep.org/}SubType2')
 
     value = xsd_type(attr_a='a', attr_b='b', attr_c='c')
     node = render_node(xsd_element, value)
@@ -395,13 +396,12 @@ def test_simple_content_extension(schema_visitor):
     """)
     schema_visitor.visit_schema(node)
     schema = schema_visitor.schema
-    schema._prefix_map['ns0'] = 'http://tests.python-zeep.org/'
 
-    record_type = schema.get_type('ns0:SubType1')
+    record_type = schema.get_type('{http://tests.python-zeep.org/}SubType1')
     child_attrs = [child.name for child in record_type._children]
     assert len(child_attrs) == 3
 
-    record_type = schema.get_type('ns0:SubType2')
+    record_type = schema.get_type('{http://tests.python-zeep.org/}SubType2')
     child_attrs = [child.name for child in record_type._children]
     assert len(child_attrs) == 4
 

--- a/tests/test_xsd_visitor.py
+++ b/tests/test_xsd_visitor.py
@@ -12,7 +12,13 @@ from zeep.xsd.types import UnresolvedType
 @pytest.fixture
 def schema_visitor():
     parser_context = ParserContext()
-    schema = SchemaDocument(parser_context=parser_context)
+    node = etree.Element('{http://www.w3.org/2001/XMLSchema}Schema')
+    schema = SchemaDocument(
+        node=node,
+        transport=None,
+        location=None,
+        parser_context=parser_context,
+        base_url=None)
     return visitor.SchemaVisitor(schema)
 
 


### PR DESCRIPTION
During parsing xsd imports are non transitive, however after the parsing
is done all global elements / types should be available even if it is
defined in a sub-sub schema. This is solved by making a clear
distinction between the main Schema interface and the various Schema
Documents its existing out of.