### PR TITLE
Ensure cache datetimes are timezone-aware (#97).

### DIFF
--- a/src/zeep/cache.py
+++ b/src/zeep/cache.py
@@ -2,27 +2,11 @@ import base64
 import datetime
 import errno
 import os
+import pytz
 import sqlite3
 
 import appdirs
 import six
-
-
-class UTC(datetime.tzinfo):
-    '''UTC tzinfo implementation taken from Python documentation.'''
-    _zero = datetime.timedelta(0)
-
-    def __repr__(self):
-        return '<UTC>'
-
-    def utcoffset(self, dt):
-        return self._zero
-
-    def tzname(self, dt):
-        return 'UTC'
-
-    def dst(self, dt):
-        return self._zero
 
 
 class SqliteCache(object):
@@ -64,9 +48,9 @@ class SqliteCache(object):
         if rows:
             created, data = rows[0]
             offset = (
-                datetime.datetime.utcnow().replace(tzinfo=UTC()) -
+                datetime.datetime.utcnow().replace(tzinfo=pytz.utc) -
                 datetime.timedelta(seconds=self._timeout))
-            if not self._timeout or created.replace(tzinfo=UTC()) > offset:
+            if not self._timeout or created.replace(tzinfo=pytz.utc) > offset:
                 return self._decode_data(data)
 
     def _encode_data(self, data):

--- a/src/zeep/cache.py
+++ b/src/zeep/cache.py
@@ -8,6 +8,23 @@ import appdirs
 import six
 
 
+class UTC(datetime.tzinfo):
+    '''UTC tzinfo implementation taken from Python documentation.'''
+    _zero = datetime.timedelta(0)
+
+    def __repr__(self):
+        return '<UTC>'
+
+    def utcoffset(self, dt):
+        return self._zero
+
+    def tzname(self, dt):
+        return 'UTC'
+
+    def dst(self, dt):
+        return self._zero
+
+
 class SqliteCache(object):
     _version = '1'
 
@@ -47,9 +64,9 @@ class SqliteCache(object):
         if rows:
             created, data = rows[0]
             offset = (
-                datetime.datetime.utcnow() -
+                datetime.datetime.utcnow().replace(tzinfo=UTC()) -
                 datetime.timedelta(seconds=self._timeout))
-            if not self._timeout or created > offset:
+            if not self._timeout or created.replace(tzinfo=UTC()) > offset:
                 return self._decode_data(data)
 
     def _encode_data(self, data):


### PR DESCRIPTION
This works for me both outside of and within Django. The UTC class I used is taken from the Python docs here: https://docs.python.org/2/library/datetime.html#datetime.tzinfo.fromutc.