### PR TITLE
Parse XML response even if it has errors

### DIFF
--- a/src/zeep/wsdl/soap.py
+++ b/src/zeep/wsdl/soap.py
@@ -110,7 +110,8 @@ class SoapBinding(Binding):
                 % response.status_code)
 
         try:
-            doc = fromstring(response.content)
+            parser = etree.XMLParser(recover=True)
+            doc = fromstring(response.content, parser)
         except etree.XMLSyntaxError:
             raise TransportError(
                 u'Server returned HTTP status %d (%s)'


### PR DESCRIPTION
Using the parser with recover=True allows XML with errors to be parsed.

If the change is not good, maybe this could be exposed as an option in zeep itself? When instantiating the client, maybe.