### PR TITLE
Add formatting options to XML posted via the transport class

### DIFF
--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -19,9 +19,10 @@ class OperationProxy(object):
         self._op_name = operation_name
 
     def __call__(self, *args, **kwargs):
+        pretty_print = kwargs.pop('pretty_print', True)
         return self._proxy._binding.send(
             self._proxy._client, self._proxy._binding_options,
-            self._op_name, args, kwargs)
+            self._op_name, args, kwargs, pretty_print=pretty_print)
 
 
 class ServiceProxy(object):

--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -19,10 +19,9 @@ class OperationProxy(object):
         self._op_name = operation_name
 
     def __call__(self, *args, **kwargs):
-        pretty_print = kwargs.pop('pretty_print', True)
         return self._proxy._binding.send(
             self._proxy._client, self._proxy._binding_options,
-            self._op_name, args, kwargs, pretty_print=pretty_print)
+            self._op_name, args, kwargs)
 
 
 class ServiceProxy(object):

--- a/src/zeep/wsdl/soap.py
+++ b/src/zeep/wsdl/soap.py
@@ -56,7 +56,7 @@ class SoapBinding(Binding):
         serialized = operation.create(*args, **kwargs)
         return serialized.content
 
-    def send(self, client, options, operation, args, kwargs, pretty_print=True):
+    def send(self, client, options, operation, args, kwargs):
         """Called from the service
 
         :param client: The client with which the operation was called
@@ -69,8 +69,6 @@ class SoapBinding(Binding):
         :type args: tuple
         :param kwargs: The **kwargs to pass to the operation
         :type kwargs: dict
-        :param pretty_print: Whether or not operation data should be sent in pretty XML or flat XML
-        :type pretty_print: bool
         """
         operation_obj = self.get(operation)
         if not operation_obj:
@@ -89,8 +87,7 @@ class SoapBinding(Binding):
         if client.wsse:
             envelope, http_headers = client.wsse.sign(envelope, headers)
 
-        content = etree_to_string(envelope, pretty_print=pretty_print)
-        response = client.transport.post(options['address'], content, headers)
+        response = client.transport.post_xml(options['address'], envelope, headers)
 
         return self.process_reply(client, operation_obj, response)
 

--- a/src/zeep/wsdl/soap.py
+++ b/src/zeep/wsdl/soap.py
@@ -56,7 +56,7 @@ class SoapBinding(Binding):
         serialized = operation.create(*args, **kwargs)
         return serialized.content
 
-    def send(self, client, options, operation, args, kwargs):
+    def send(self, client, options, operation, args, kwargs, pretty_print=True):
         """Called from the service
 
         :param client: The client with which the operation was called
@@ -69,7 +69,8 @@ class SoapBinding(Binding):
         :type args: tuple
         :param kwargs: The **kwargs to pass to the operation
         :type kwargs: dict
-
+        :param pretty_print: Whether or not operation data should be sent in pretty XML or flat XML
+        :type pretty_print: bool
         """
         operation_obj = self.get(operation)
         if not operation_obj:
@@ -88,7 +89,7 @@ class SoapBinding(Binding):
         if client.wsse:
             envelope, http_headers = client.wsse.sign(envelope, headers)
 
-        content = etree_to_string(envelope)
+        content = etree_to_string(envelope, pretty_print=pretty_print)
         response = client.transport.post(options['address'], content, headers)
 
         return self.process_reply(client, operation_obj, response)

--- a/src/zeep/wsdl/utils.py
+++ b/src/zeep/wsdl/utils.py
@@ -1,9 +1,10 @@
 from lxml import etree
 
 
-def etree_to_string(node):
+def etree_to_string(node, pretty_print=True):
+    print pretty_print
     return etree.tostring(
-        node, pretty_print=True, xml_declaration=True, encoding='utf-8')
+        node, pretty_print=pretty_print, xml_declaration=True, encoding='utf-8')
 
 
 def combine_schemas(schema_nodes, location, parser_context):

--- a/src/zeep/wsdl/utils.py
+++ b/src/zeep/wsdl/utils.py
@@ -1,10 +1,9 @@
 from lxml import etree
 
 
-def etree_to_string(node, pretty_print=True):
-    print pretty_print
+def etree_to_string(node, pretty_print=True, xml_declaration=True, encoding='utf-8', **formatting_options):
     return etree.tostring(
-        node, pretty_print=pretty_print, xml_declaration=True, encoding='utf-8')
+        node, pretty_print=pretty_print, xml_declaration=xml_declaration, encoding=encoding, **formatting_options)
 
 
 def combine_schemas(schema_nodes, location, parser_context):


### PR DESCRIPTION
If you'd rather not add the change, I understand - we just have to consume a (bad) "SOAP" api that requires non-pretty_print XML or it spits back a 500, so this option is useful for us.