### PR TITLE
Fixed omitting soap body for RPC input body without parts

### DIFF
--- a/src/zeep/wsdl/messages.py
+++ b/src/zeep/wsdl/messages.py
@@ -290,7 +290,7 @@ class RpcMessage(SoapMessage):
 
         # If this message has no parts then we have nothing to do. This might
         # happen for output messages which don't return anything.
-        if not self.abstract.parts:
+        if not self.abstract.parts and self.type != 'input':
             return
 
         parts = OrderedDict(self.abstract.parts)

--- a/tests/test_wsdl_messages_rpc.py
+++ b/tests/test_wsdl_messages_rpc.py
@@ -59,6 +59,53 @@ def test_serialize():
     assert_nodes_equal(expected, serialized.content)
 
 
+def test_serialize_empty_input():
+    wsdl_content = StringIO("""
+    <definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+                 xmlns:tns="http://tests.python-zeep.org/tns"
+                 xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                 targetNamespace="http://tests.python-zeep.org/tns">
+
+      <portType name="TestPortType">
+        <operation name="TestOperation">
+          <input message="tns:TestOperationRequests"/>
+        </operation>
+      </portType>
+
+      <message name="TestOperationRequests"/>
+
+      <binding name="TestBinding" type="tns:TestPortType">
+        <soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="TestOperation">
+          <soap:operation soapAction=""/>
+          <input>
+            <soap:body use="encoded"
+                       namespace="http://test.python-zeep.org/tests/rpc"/>
+          </input>
+        </operation>
+      </binding>
+    </definitions>
+    """.strip())
+
+    root = wsdl.Document(wsdl_content, None)
+
+    binding = root.bindings['{http://tests.python-zeep.org/tns}TestBinding']
+    operation = binding.get('TestOperation')
+
+    serialized = operation.input.serialize()
+    expected = """
+        <?xml version="1.0"?>
+        <soap-env:Envelope
+            xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
+          <soap-env:Body>
+            <ns0:TestOperation xmlns:ns0="http://test.python-zeep.org/tests/rpc"/>
+          </soap-env:Body>
+        </soap-env:Envelope>
+    """
+    assert_nodes_equal(expected, serialized.content)
+
+
 def test_deserialize():
     wsdl_content = StringIO("""
     <definitions xmlns="http://schemas.xmlsoap.org/wsdl/"


### PR DESCRIPTION
I had a issue with sending the getDomainNames operation of this wsdl: https://api.transip.nl/wsdl/?service=DomainService

Because the input has no 'parts' the whole body of the message is omitted resulting in:

```
[28/Jul/2016 17:38:48] HTTP Post to https://api.transip.nl/soap/?service=DomainService:
<?xml version='1.0' encoding='utf-8'?>
<soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"/>

[28/Jul/2016 17:38:48] HTTP Response from https://api.transip.nl/soap/?service=DomainService (status: 500):
<?xml version="1.0" encoding="UTF-8"?>
<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
    <SOAP-ENV:Body>
        <SOAP-ENV:Fault>
            <faultcode>SOAP-ENV:Client</faultcode>
            <faultstring>Body must be present in a SOAP envelope</faultstring>
        </SOAP-ENV:Fault>
    </SOAP-ENV:Body>
</SOAP-ENV:Envelope>

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "transipy/services/domain_service.py", line 39, in get_domain_names
    return self.zeep.service.getDomainNames()
  File "/usr/lib/python2.7/site-packages/zeep/client.py", line 24, in __call__
    self._op_name, args, kwargs)
  File "/usr/lib/python2.7/site-packages/zeep/wsdl/soap.py", line 94, in send
    return self.process_reply(client, operation_obj, response)
  File "/usr/lib/python2.7/site-packages/zeep/wsdl/soap.py", line 123, in process_reply
    return self.process_error(doc)
  File "/usr/lib/python2.7/site-packages/zeep/wsdl/soap.py", line 202, in process_error
    detail=fault_node.find('detail'))
zeep.exceptions.Fault: Body must be present in a SOAP envelope
```

After expanding the if condition a empty body will be created for a input message which results in:

```
[28/Jul/2016 17:40:33] HTTP Post to https://api.transip.nl/soap/?service=DomainService:
<?xml version='1.0' encoding='utf-8'?>
<soap-env:Envelope xmlns:ns0="http://www.transip.nl/soap" xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
  <soap-env:Body>
    <ns0:getDomainNames/>
  </soap-env:Body>
</soap-env:Envelope>


[28/Jul/2016 17:40:33] HTTP Response from https://api.transip.nl/soap/?service=DomainService (status: 500):
<?xml version="1.0" encoding="UTF-8"?>
<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
    <SOAP-ENV:Body>
        <SOAP-ENV:Fault>
            <faultcode>201</faultcode>
            <faultstring>The API is not enabled for this customer (timestamp: 0.43074400 1469720433)</faultstring>
        </SOAP-ENV:Fault>
    </SOAP-ENV:Body>
</SOAP-ENV:Envelope>
```

Still a soap error but that's because I have disabled the api access at the moment.

The same problem could apply for other message type but I do not have a use-case to validate that.