### PR TITLE
Add support for Transport-specified timeout in XML GET/POST requests

### DIFF
--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -52,15 +52,17 @@ class Transport(object):
         with open(url, 'rb') as fh:
             return fh.read()
 
-    def post(self, address, message, headers):
+    def post(self, address, message, headers, timeout=NotSet):
+        timeout = self.timeout if timeout is NotSet else timeout
         self.logger.debug("HTTP Post to %s:\n%s", address, message)
-        response = self.session.post(address, data=message, headers=headers)
+        response = self.session.post(
+            address, data=message, headers=headers, timeout=timeout)
         self.logger.debug(
             "HTTP Response from %s (status: %d):\n%s",
             address, response.status_code, response.content)
         return response
 
-    def post_xml(self, address, envelope, headers):
+    def post_xml(self, address, envelope, headers, timeout=NotSet):
         """Post the envelope xml element to the given address with the headers.
 
         This method is intended to be overriden if you want to customize the
@@ -69,8 +71,10 @@ class Transport(object):
 
         """
         message = etree_to_string(envelope)
-        return self.post(address, message, headers)
+        return self.post(address, message, headers, timeout=timeout)
 
-    def get(self, address, params, headers):
-        response = self.session.get(address, params=params, headers=headers)
+    def get(self, address, params, headers, timeout=NotSet):
+        timeout = self.timeout if timeout is NotSet else timeout
+        response = self.session.get(
+            address, params=params, headers=headers, timeout=timeout)
         return response

--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -10,7 +10,7 @@ from zeep.wsdl.utils import etree_to_string
 
 class Transport(object):
 
-    def __init__(self, cache=NotSet, timeout=300, verify=True, http_auth=None):
+    def __init__(self, cache=NotSet, timeout=NotSet, verify=True, http_auth=None):
         self.cache = SqliteCache() if cache is NotSet else cache
         self.timeout = timeout
         self.verify = verify
@@ -37,7 +37,8 @@ class Transport(object):
                 if response:
                     return bytes(response)
 
-            response = self.session.get(url, timeout=self.timeout)
+            timeout = 300 if self.timeout is NotSet else self.timeout
+            response = self.session.get(url, timeout=timeout)
             response.raise_for_status()
 
             if self.cache:
@@ -52,7 +53,8 @@ class Transport(object):
         with open(url, 'rb') as fh:
             return fh.read()
 
-    def post(self, address, message, headers, timeout=None):
+    def post(self, address, message, headers):
+        timeout = None if self.timeout is NotSet else self.timeout
         self.logger.debug("HTTP Post to %s:\n%s", address, message)
         response = self.session.post(
             address, data=message, headers=headers, timeout=timeout)
@@ -61,7 +63,7 @@ class Transport(object):
             address, response.status_code, response.content)
         return response
 
-    def post_xml(self, address, envelope, headers, timeout=None):
+    def post_xml(self, address, envelope, headers):
         """Post the envelope xml element to the given address with the headers.
 
         This method is intended to be overriden if you want to customize the
@@ -70,9 +72,10 @@ class Transport(object):
 
         """
         message = etree_to_string(envelope)
-        return self.post(address, message, headers, timeout=timeout)
+        return self.post(address, message, headers)
 
-    def get(self, address, params, headers, timeout=None):
+    def get(self, address, params, headers):
+        timeout = None if self.timeout is NotSet else self.timeout
         response = self.session.get(
             address, params=params, headers=headers, timeout=timeout)
         return response

--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -52,8 +52,7 @@ class Transport(object):
         with open(url, 'rb') as fh:
             return fh.read()
 
-    def post(self, address, message, headers, timeout=NotSet):
-        timeout = self.timeout if timeout is NotSet else timeout
+    def post(self, address, message, headers, timeout=None):
         self.logger.debug("HTTP Post to %s:\n%s", address, message)
         response = self.session.post(
             address, data=message, headers=headers, timeout=timeout)
@@ -62,7 +61,7 @@ class Transport(object):
             address, response.status_code, response.content)
         return response
 
-    def post_xml(self, address, envelope, headers, timeout=NotSet):
+    def post_xml(self, address, envelope, headers, timeout=None):
         """Post the envelope xml element to the given address with the headers.
 
         This method is intended to be overriden if you want to customize the
@@ -73,8 +72,7 @@ class Transport(object):
         message = etree_to_string(envelope)
         return self.post(address, message, headers, timeout=timeout)
 
-    def get(self, address, params, headers, timeout=NotSet):
-        timeout = self.timeout if timeout is NotSet else timeout
+    def get(self, address, params, headers, timeout=None):
         response = self.session.get(
             address, params=params, headers=headers, timeout=timeout)
         return response


### PR DESCRIPTION
This fixes issue #140 which disregards the timeout passed to `Transport` for any request except the one that fetches the wsdl/xsd.

This has some weird considerations in that by default the wsdl/xsd fetch is 300s, but there is no timeout set for get/post requests. Any "reasonable" request would be much less than that, but you can't go about assuming that people won't be making a 2000s request. As such, I set the timeout by default to `NotSet` and assigned it to `300` for `load()` and `None` for get/post if it was not set on instantiation of the Transport.

This could potentially break implementations where a load timeout is explicitly set, but the get/post request should not have a timeout. Not sure what your thoughts on that are.

Anyway, this would be hugely useful for me to get this merged. Not familiar with your testing/coverage concerns but tox seems to pass for this. Thanks.

@mvantellingen 