### PR TITLE
Add try catch block when accessing node.getchildren()[0]

### DIFF
--- a/src/zeep/wsdl/http.py
+++ b/src/zeep/wsdl/http.py
@@ -143,16 +143,20 @@ class HttpOperation(Operation):
                 continue
 
             # XXX Multiple mime types may be declared as alternatives
-            message_node = node.getchildren()[0]
+            try:
+                message_node = node.getchildren()[0]
+            except IndexError:
+                message_node = None
             message_class = None
-            if message_node.tag == etree.QName(NSMAP['http'], 'urlEncoded'):
-                message_class = messages.UrlEncoded
-            elif message_node.tag == etree.QName(NSMAP['http'], 'urlReplacement'):
-                message_class = messages.UrlReplacement
-            elif message_node.tag == etree.QName(NSMAP['mime'], 'content'):
-                message_class = messages.MimeContent
-            elif message_node.tag == etree.QName(NSMAP['mime'], 'mimeXml'):
-                message_class = messages.MimeXML
+            if message_node != None:
+                if message_node.tag == etree.QName(NSMAP['http'], 'urlEncoded'):
+                    message_class = messages.UrlEncoded
+                elif message_node.tag == etree.QName(NSMAP['http'], 'urlReplacement'):
+                    message_class = messages.UrlReplacement
+                elif message_node.tag == etree.QName(NSMAP['mime'], 'content'):
+                    message_class = messages.MimeContent
+                elif message_node.tag == etree.QName(NSMAP['mime'], 'mimeXml'):
+                    message_class = messages.MimeXML            
 
             if message_class:
                 msg = message_class.parse(definitions, node, obj)

--- a/src/zeep/wsdl/http.py
+++ b/src/zeep/wsdl/http.py
@@ -143,12 +143,11 @@ class HttpOperation(Operation):
                 continue
 
             # XXX Multiple mime types may be declared as alternatives
-            try:
+            message_node = None
+            if len(node.getchildren()) > 0:
                 message_node = node.getchildren()[0]
-            except IndexError:
-                message_node = None
             message_class = None
-            if message_node != None:
+            if message_node is not None:
                 if message_node.tag == etree.QName(NSMAP['http'], 'urlEncoded'):
                     message_class = messages.UrlEncoded
                 elif message_node.tag == etree.QName(NSMAP['http'], 'urlReplacement'):

--- a/tests/test_wsdl.py
+++ b/tests/test_wsdl.py
@@ -798,3 +798,57 @@ def test_wsdl_import_xsd_references(recwarn):
     transport.bind('http://tests.python-zeep.org/schema-2.wsdl', wsdl_2)
     document = wsdl.Document(wsdl_main, transport)
     document.dump()
+
+
+def test_parse_operation_empty_nodes():
+    content = StringIO("""
+        <?xml version="1.0"?>
+        <wsdl:definitions xmlns:s="http://www.w3.org/2001/XMLSchema" 
+            xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+            xmlns:tns="http://tests.python-zeep.org/"
+            xmlns:s1="http://microsoft.com/wsdl/types/" 
+            xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" 
+            xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/"
+            targetNamespace="http://tests.python-zeep.org/" 
+            xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+          <wsdl:types>
+            <s:schema targetNamespace="http://tests.python-zeep.org/">
+              <s:import namespace="http://microsoft.com/wsdl/types/" />
+              <s:element name="ExampleMethod">
+              </s:element>
+            </s:schema>
+            <s:schema targetNamespace="http://microsoft.com/wsdl/types/">
+              <s:simpleType name="char">
+                <s:restriction base="s:unsignedShort" />
+              </s:simpleType>
+            </s:schema>
+          </wsdl:types>
+          <wsdl:message name="MessageIn">
+            <wsdl:part name="parameters" element="tns:ExampleMethod" />
+          </wsdl:message>
+          <wsdl:message name="MessageOut">
+            <wsdl:part name="parameters" element="tns:ExampleMethod" />
+          </wsdl:message>
+          <wsdl:portType name="ExampleSoap">
+            <wsdl:operation name="ExampleMethod">
+              <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+                Example documentation.
+              </wsdl:documentation>
+              <wsdl:input message="tns:MessageIn" />
+              <wsdl:output message="tns:MessageOut" />
+            </wsdl:operation>
+          </wsdl:portType>
+          <wsdl:binding name="ExampleSoap" type="tns:ExampleSoap">
+            <http:binding verb="POST" />
+            <wsdl:operation name="ExampleMethod">
+              <http:operation location="/ExampleMethod" />
+              <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+              </wsdl:input>
+              <wsdl:output />
+            </wsdl:operation>
+          </wsdl:binding>
+        </wsdl:definitions>
+    """.strip())
+
+    assert wsdl.Document(content, None)


### PR DESCRIPTION
I ran into an `IndexError: list index out of range` with a fairly complex WSDL that I don't have any control over. Adding this check got it working for me.