### PR TITLE
Refactor deserializing SOAP messags (document/rpc)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ tests_require = [
     'pytest-cov==2.3.1',
     'pytest==3.0.2',
     'requests_mock>=0.7.0',
-    'pdbpp==0.8.3',
 
     # Linting
     'isort==4.2.5',

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ tests_require = [
     'pytest-cov==2.3.1',
     'pytest==3.0.2',
     'requests_mock>=0.7.0',
+    'pdbpp==0.8.3',
 
     # Linting
     'isort==4.2.5',

--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -53,11 +53,23 @@ class Transport(object):
             return fh.read()
 
     def post(self, address, message, headers):
-        self.logger.debug("HTTP Post to %s:\n%s", address, message)
+        if self.logger.isEnabledFor(logging.DEBUG):
+            log_message = message
+            if isinstance(log_message, bytes):
+                log_message = log_message.decode('utf-8')
+            self.logger.debug("HTTP Post to %s:\n%s", address, log_message)
+
         response = self.session.post(address, data=message, headers=headers)
-        self.logger.debug(
-            "HTTP Response from %s (status: %d):\n%s",
-            address, response.status_code, response.content)
+
+        if self.logger.isEnabledFor(logging.DEBUG):
+            log_message = response.content
+            if isinstance(log_message, bytes):
+                log_message = log_message.decode('utf-8')
+
+            self.logger.debug(
+                "HTTP Response from %s (status: %d):\n%s",
+                address, response.status_code, log_message)
+
         return response
 
     def post_xml(self, address, envelope, headers):

--- a/src/zeep/wsdl/messages.py
+++ b/src/zeep/wsdl/messages.py
@@ -137,6 +137,8 @@ class SoapMessage(ConcreteMessage):
 
         body_info = self._info['body']
         if body_info:
+            # If the part name is omitted then all parts are available under
+            # the soap:body tag. Otherwise only the part with the given name.
             if body_info['part']:
                 part_name = body_info['part']
             else:
@@ -225,7 +227,6 @@ class SoapMessage(ConcreteMessage):
 
     @classmethod
     def _parse_header(cls, xmlelements, tns):
-        """Parse the soap:header / soap:headerfault elements
         """Parse the soap:header and optionally included soap:headerfault elements
 
           <soap:header

--- a/src/zeep/wsdl/messages.py
+++ b/src/zeep/wsdl/messages.py
@@ -129,7 +129,9 @@ class SoapMessage(ConcreteMessage):
         header = envelope.find('soap-env:Header', namespaces=self.nsmap)
         headers_result = self._deserialize_headers(header)
 
-        result = self.envelope(**body_result, **headers_result)
+        kwargs = body_result
+        kwargs.update(headers_result)
+        result = self.envelope(**kwargs)
 
         if len(result) > 1:
             return result

--- a/src/zeep/wsdl/messages.py
+++ b/src/zeep/wsdl/messages.py
@@ -326,7 +326,6 @@ class DocumentMessage(SoapMessage):
     """
 
     def _deserialize_body(self, xmlelement):
-        # Deserialize body elements
         if self.body.name:
             xmlelement = xmlelement.getchildren()[0]
             result = self.body.parse(xmlelement, self.wsdl.types)
@@ -334,7 +333,10 @@ class DocumentMessage(SoapMessage):
             result = self.body.parse(xmlelement, self.wsdl.types)
 
         if result is not None:
-            return result.__values__
+            if isinstance(result, xsd.CompoundValue):
+                return result.__values__
+            else:
+                return {self.body.attr_name: result}
         return {}
 
     def resolve(self, definitions, abstract_message):
@@ -401,7 +403,11 @@ class RpcMessage(SoapMessage):
         value = body_element.find(self.body.qname)
         result = self.body.parse(value, self.wsdl.types)
         if result is not None:
-            return result.__values__
+            if isinstance(result, xsd.CompoundValue):
+                return result.__values__
+            else:
+                return {self.body.attr_name: result}
+        return {}
 
     def resolve(self, definitions, abstract_message):
         """Override the default `SoapMessage.resolve()` since we need to wrap

--- a/src/zeep/wsdl/soap.py
+++ b/src/zeep/wsdl/soap.py
@@ -271,9 +271,7 @@ class SoapOperation(Operation):
                 "{%s}Envelope root element. The root element found is %s "
             ) % (envelope_qname.namespace, envelope.tag))
 
-        body = envelope.find('soap-env:Body', namespaces=self.nsmap)
-        assert body is not None, "No {%s}Body element found" % (self.nsmap['soap-env'])
-        return self.output.deserialize(body)
+        return self.output.deserialize(envelope)
 
     @classmethod
     def parse(cls, definitions, xmlelement, binding, nsmap):

--- a/src/zeep/xsd/builtins.py
+++ b/src/zeep/xsd/builtins.py
@@ -572,6 +572,7 @@ default_types = {
 
 class Schema(Base):
     name = 'schema'
+    attr_name = 'schema'
     qname = '{http://www.w3.org/2001/XMLSchema}schema'
 
     def clone(self, qname, min_occurs=1, max_occurs=1):

--- a/src/zeep/xsd/elements.py
+++ b/src/zeep/xsd/elements.py
@@ -30,7 +30,7 @@ class Base(object):
             return result, args
 
         value = args.pop(0)
-        return {self.name: value}, args
+        return {self.attr_name: value}, args
 
     def parse_kwargs(self, kwargs, name=None):
         raise NotImplementedError()
@@ -180,7 +180,7 @@ class Any(Base):
 
 class Element(Base):
     def __init__(self, name, type_=None, min_occurs=1, max_occurs=1,
-                 nillable=False, default=None, is_global=False):
+                 nillable=False, default=None, is_global=False, attr_name=None):
         if name and not isinstance(name, etree.QName):
             name = etree.QName(name)
 
@@ -192,6 +192,7 @@ class Element(Base):
         self.nillable = nillable
         self.is_global = is_global
         self.default = default
+        self.attr_name = attr_name or self.name
         # assert type_
 
     def __str__(self):
@@ -227,6 +228,7 @@ class Element(Base):
         new = copy.copy(self)
         new.name = name.localname
         new.qname = name
+        new.attr_name = new.name
         new.min_occurs = min_occurs
         new.max_occurs = max_occurs
         return new
@@ -248,7 +250,7 @@ class Element(Base):
             xmlelement, schema, allow_none=allow_none, context=context)
 
     def parse_kwargs(self, kwargs, name=None):
-        return self.type.parse_kwargs(kwargs, name or self.name)
+        return self.type.parse_kwargs(kwargs, name or self.attr_name)
 
     def parse_xmlelements(self, xmlelements, schema, name=None, context=None):
         """Consume matching xmlelements and call parse() on each of them"""

--- a/src/zeep/xsd/elements.py
+++ b/src/zeep/xsd/elements.py
@@ -221,14 +221,16 @@ class Element(Base):
         value = [] if self.accepts_multiple else self.default
         return value
 
-    def clone(self, name, min_occurs=1, max_occurs=1):
-        if not isinstance(name, etree.QName):
-            name = etree.QName(name)
-
+    def clone(self, name=None, min_occurs=1, max_occurs=1):
         new = copy.copy(self)
-        new.name = name.localname
-        new.qname = name
-        new.attr_name = new.name
+
+        if name:
+            if not isinstance(name, etree.QName):
+                name = etree.QName(name)
+            new.name = name.localname
+            new.qname = name
+            new.attr_name = new.name
+
         new.min_occurs = min_occurs
         new.max_occurs = max_occurs
         return new

--- a/src/zeep/xsd/indicators.py
+++ b/src/zeep/xsd/indicators.py
@@ -75,7 +75,7 @@ class OrderIndicator(Indicator, list):
             elif isinstance(elm, (Any, Choice)):
                 result.append((generator.get_name(), elm))
             else:
-                name = generator_2.create_name(elm.name)
+                name = generator_2.create_name(elm.attr_name)
                 result.append((name, elm))
         return result
 

--- a/src/zeep/xsd/types.py
+++ b/src/zeep/xsd/types.py
@@ -223,7 +223,7 @@ class ComplexType(Type):
         result = []
         for name, element in self.elements_nested:
             if isinstance(element, Element):
-                result.append((element.name, element))
+                result.append((element.attr_name, element))
             else:
                 result.extend(element.elements)
         return result

--- a/tests/test_wsdl.py
+++ b/tests/test_wsdl.py
@@ -120,7 +120,7 @@ def test_parse_soap_header_wsdl():
             kwargs={
                 'tickerSymbol': 'foobar',
                 '_soapheaders': {
-                    'Authentication': {
+                    'header': {
                         'username': 'ikke',
                         'password': 'oeh-is-geheim!',
                     }

--- a/tests/test_wsdl_messages_document.py
+++ b/tests/test_wsdl_messages_document.py
@@ -655,105 +655,147 @@ def test_serializer_with_header_custom_xml():
 
 
 def test_deserialize():
+    wsdl_content = StringIO("""
+    <definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+                 xmlns:tns="http://tests.python-zeep.org/tns"
+                 xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                 targetNamespace="http://tests.python-zeep.org/tns">
+      <types>
+        <xsd:schema targetNamespace="http://tests.python-zeep.org/tns"
+                    elementFormDefault="qualified">
+          <xsd:element name="Request">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="arg1" type="xsd:string"/>
+                <xsd:element name="arg2" type="xsd:string"/>
+              </xsd:sequence>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:schema>
+      </types>
+
+      <message name="Input">
+        <part element="tns:Request"/>
+      </message>
+      <message name="Output">
+        <part element="tns:Request"/>
+      </message>
+
+      <portType name="TestPortType">
+        <operation name="TestOperation">
+          <input message="Input"/>
+          <output message="Output"/>
+        </operation>
+      </portType>
+
+      <binding name="TestBinding" type="tns:TestPortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="TestOperation">
+          <soap:operation soapAction=""/>
+          <input>
+            <soap:body use="literal"/>
+          </input>
+          <output>
+            <soap:body use="literal"/>
+          </output>
+        </operation>
+      </binding>
+    </definitions>
+    """.strip())
+
+    root = wsdl.Document(wsdl_content, None)
+
+    binding = root.bindings['{http://tests.python-zeep.org/tns}TestBinding']
+    operation = binding.get('TestOperation')
+
     response_body = load_xml("""
-        <SOAP-ENV:Body
-            xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-          <mns:response xmlns:mns="http://test.python-zeep.org/tests/document"
-                SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-            <mns:return type="xsd:string">foobar</mns:return>
-          </mns:response>
-        </SOAP-ENV:Body>
-    """)  # noqa
-    wsdl = stub(types=stub(
-        _prefix_map={},
-        _get_schema_document=lambda namespace: None
-    ))
-    operation = stub(soapaction='my-action', name='something')
-
-    msg = messages.DocumentMessage(
-        wsdl=wsdl,
-        name=None,
-        operation=operation,
-        nsmap=soap.Soap11Binding.nsmap,
-        type='input')
-
-    # Fake resolve()
-    namespace = 'http://test.python-zeep.org/tests/document'
-    msg.abstract = definitions.AbstractMessage(
-        etree.QName(namespace, 'Method1Response'))
-    msg.abstract.parts = OrderedDict([
-        ('body', definitions.MessagePart(
-            element=xsd.Element(
-                etree.QName(namespace, 'response'),
-                xsd.ComplexType([
-                    xsd.Element(etree.QName(namespace, 'return'), xsd.String()),
-                ])
-            ),
-            type=None))
-        ])
-
-    msg.namespace = {
-        'body': 'http://test.python-zeep.org/tests/document',
-        'header': None,
-        'headerfault': None
-    }
-
-    result = msg.deserialize(response_body)
-    assert result == 'foobar'
+        <?xml version="1.0"?>
+        <soap-env:Envelope
+            xmlns:ns0="http://tests.python-zeep.org/tns"
+            xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
+          <soap-env:Body>
+            <ns0:Request>
+              <ns0:arg1>ah1</ns0:arg1>
+              <ns0:arg2>ah2</ns0:arg2>
+            </ns0:Request>
+          </soap-env:Body>
+        </soap-env:Envelope>
+    """)
+    result = operation.process_reply(response_body)
+    assert result.arg1 == 'ah1'
+    assert result.arg2 == 'ah2'
 
 
 def test_deserialize_choice():
+    wsdl_content = StringIO("""
+    <definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+                 xmlns:tns="http://tests.python-zeep.org/tns"
+                 xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                 targetNamespace="http://tests.python-zeep.org/tns">
+      <types>
+        <xsd:schema targetNamespace="http://tests.python-zeep.org/tns"
+                    elementFormDefault="qualified">
+          <xsd:element name="Request">
+            <xsd:complexType>
+              <xsd:choice>
+                <xsd:element name="arg1" type="xsd:string"/>
+                <xsd:element name="arg2" type="xsd:string"/>
+              </xsd:choice>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:schema>
+      </types>
+
+      <message name="Input">
+        <part element="tns:Request"/>
+      </message>
+      <message name="Output">
+        <part element="tns:Request"/>
+      </message>
+
+      <portType name="TestPortType">
+        <operation name="TestOperation">
+          <input message="Input"/>
+          <output message="Output"/>
+        </operation>
+      </portType>
+
+      <binding name="TestBinding" type="tns:TestPortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="TestOperation">
+          <soap:operation soapAction=""/>
+          <input>
+            <soap:body use="literal"/>
+          </input>
+          <output>
+            <soap:body use="literal"/>
+          </output>
+        </operation>
+      </binding>
+    </definitions>
+    """.strip())
+
+    root = wsdl.Document(wsdl_content, None)
+
+    binding = root.bindings['{http://tests.python-zeep.org/tns}TestBinding']
+    operation = binding.get('TestOperation')
+
     response_body = load_xml("""
-        <SOAP-ENV:Body
-            xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-          <mns:response xmlns:mns="http://test.python-zeep.org/tests/document"
-                SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-            <mns:return type="xsd:string">foobar</mns:return>
-          </mns:response>
-        </SOAP-ENV:Body>
-    """)  # noqa
-    wsdl = stub(types=stub(
-        _prefix_map={},
-        _get_schema_document=lambda namespace: None
-    ))
-    operation = stub(soapaction='my-action', name='something')
-
-    msg = messages.DocumentMessage(
-        wsdl=wsdl,
-        name=None,
-        operation=operation,
-        nsmap=soap.Soap11Binding.nsmap,
-        type='input')
-
-    # Fake resolve()
-    namespace = 'http://test.python-zeep.org/tests/document'
-    msg.abstract = definitions.AbstractMessage(
-        etree.QName(namespace, 'Method1Response'))
-    msg.abstract.parts = OrderedDict([
-        ('body', definitions.MessagePart(
-            element=xsd.Element(
-                etree.QName(namespace, 'response'),
-                xsd.ComplexType(
-                    xsd.Choice([
-                        xsd.Element(etree.QName(namespace, 'return'), xsd.String()),
-                    ])
-                )
-            ),
-            type=None))
-        ])
-
-    msg.namespace = {
-        'body': 'http://test.python-zeep.org/tests/document',
-        'header': None,
-        'headerfault': None
-    }
-
-    result = msg.deserialize(response_body)
-    assert result == 'foobar'
+        <?xml version="1.0"?>
+        <soap-env:Envelope
+            xmlns:ns0="http://tests.python-zeep.org/tns"
+            xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
+          <soap-env:Body>
+            <ns0:Request>
+              <ns0:arg1>ah1</ns0:arg1>
+            </ns0:Request>
+          </soap-env:Body>
+        </soap-env:Envelope>
+    """)
+    result = operation.process_reply(response_body)
+    assert result.arg1 == 'ah1'
 
 
 def test_deserialize_one_part():

--- a/tests/test_wsdl_messages_rpc.py
+++ b/tests/test_wsdl_messages_rpc.py
@@ -234,9 +234,7 @@ def test_wsdl_array_of_simple_types():
     """)
 
     deserialized = operation.output.deserialize(document)
-    list_of_items = deserialized['_value_1']
-
-    assert list_of_items == ['item', 'and', 'even', 'more', 'items']
+    assert deserialized == ['item', 'and', 'even', 'more', 'items']
 
 
 def test_handle_incorrectly_qualified():

--- a/tests/test_wsdl_messages_rpc.py
+++ b/tests/test_wsdl_messages_rpc.py
@@ -143,12 +143,14 @@ def test_deserialize():
     operation = binding.get('TestOperation')
 
     document = load_xml("""
-        <soap-env:Body
+        <soap-env:Envelope
           xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
-          <ns0:Output xmlns:ns0="http://test.python-zeep.org/tests/rpc">
-            <result>ah1</result>
-          </ns0:Output>
-        </soap-env:Body>
+          <soap-env:Body>
+            <ns0:Output xmlns:ns0="http://test.python-zeep.org/tests/rpc">
+              <result>ah1</result>
+            </ns0:Output>
+          </soap-env:Body>
+        </soap-env:Envelope>
     """)
     assert operation.output.signature(True) == 'xsd:string'
     result = operation.output.deserialize(document)
@@ -211,12 +213,13 @@ def test_wsdl_array_of_simple_types():
     operation = binding.get('getSimpleArray')
 
     document = load_xml("""
-    <SOAP-ENV:Body SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+    <SOAP-ENV:Envelope SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
         xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
         xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:ns1="http://tests.python-zeep.org/tns"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <SOAP-ENV:Body>
         <ns1:getSimpleArrayResponse>
             <return SOAP-ENC:arrayType="xsd:string[16]" xsi:type="ns1:ArrayOfString">
                 <item xsi:type="xsd:string">item</item>
@@ -226,7 +229,8 @@ def test_wsdl_array_of_simple_types():
                 <item xsi:type="xsd:string">items</item>
             </return>
         </ns1:getSimpleArrayResponse>
-    </SOAP-ENV:Body>
+      </SOAP-ENV:Body>
+    </SOAP-ENV:Envelope>
     """)
 
     deserialized = operation.output.deserialize(document)
@@ -284,14 +288,16 @@ def test_handle_incorrectly_qualified():
     operation = binding.get('getItem')
 
     document = load_xml("""
-    <soapenv:Body
+    <soapenv:Envelope
         xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-      <ns1:getResponse soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns1="http://tests.python-zeep.org/tns">
-        <ns1:getItemReturn xsi:type="xsd:string">foobar</ns1:getItemReturn>
-      </ns1:getResponse>
-    </soapenv:Body>
+      <soapenv:Body>
+        <ns1:getResponse soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns1="http://tests.python-zeep.org/tns">
+          <ns1:getItemReturn xsi:type="xsd:string">foobar</ns1:getItemReturn>
+        </ns1:getResponse>
+      </soapenv:Body>
+    </soapenv:Envelope>
     """)
     deserialized = operation.output.deserialize(document)
     assert deserialized == 'foobar'

--- a/tests/test_wsdl_messages_rpc.py
+++ b/tests/test_wsdl_messages_rpc.py
@@ -152,7 +152,7 @@ def test_deserialize():
           </soap-env:Body>
         </soap-env:Envelope>
     """)
-    assert operation.output.signature(True) == 'xsd:string'
+    assert operation.output.signature(True) == 'body: {result: xsd:string}, header: {}'
     result = operation.output.deserialize(document)
     assert result == 'ah1'
 

--- a/tests/test_xsd.py
+++ b/tests/test_xsd.py
@@ -565,3 +565,23 @@ def test_element_attribute_name_conflict():
     assert obj.item == 'foo'
     assert obj.foo == 'x'
     assert obj.attr__item == 'bar'
+
+
+def test_attr_name():
+    custom_type = xsd.Element(
+        etree.QName('http://tests.python-zeep.org/', 'authentication'),
+        xsd.ComplexType(
+            xsd.Sequence([
+                xsd.Element(
+                    etree.QName('http://tests.python-zeep.org/', 'UserName'),
+                    xsd.String(),
+                    attr_name='username'),
+                xsd.Element(
+                    etree.QName('http://tests.python-zeep.org/', 'Password_x'),
+                    xsd.String(),
+                    attr_name='password'),
+            ])
+        ))
+
+    # sequences
+    custom_type(username='foo', password='bar')

--- a/tox.ini
+++ b/tox.ini
@@ -3,5 +3,5 @@ envlist = py27,py33,py34,py35,pypy
 
 [testenv]
 commands = 
-    pip install -e .[test]
+    pip install .[test]
     py.test -vvv


### PR DESCRIPTION
This pull-request refactors the deserialization process of soap messages. It adds support for multiple message parts for document messages and also returns the soap headers returned by the server.

Due to the fact that more data is returned these changes might be backwards incompatible.

This should fix #180 
