### PR TITLE
Add support for concurrent requests via asyncio and aiohttp

### DIFF
--- a/examples/async_example.py
+++ b/examples/async_example.py
@@ -1,0 +1,48 @@
+import asyncio
+from lxml import etree
+from zeep.client import AsyncClient, AsyncTransport
+from zeep.exceptions import Fault
+
+
+"""Example using AsyncClient to make concurrent requests to the Global Weather service.
+Determines how many cities are on record for each country.
+Run this example multiple times (noting the order in which Countries appear in the console) to observe concurrency.
+"""
+
+def handle_fut(fut):
+    # Callback scheduled by add_done_callback - will be called when future is done.
+    for resp in fut.result():
+        if issubclass(resp.__class__, Fault):
+            print(resp)
+        else:
+            print(parse_response(resp))
+
+def parse_response(resp):
+    # Parse the response and return the number of countries on record for the country.
+    doc = etree.XML(resp)
+    country_name = doc.find('.//Country').text
+    no_cities = len(doc.findall('.//City'))
+    return '{} has {} cities on record.'.format(country_name, no_cities)
+    
+
+if __name__ == "__main__":
+
+    loop = asyncio.get_event_loop()
+    
+    # Pass asyncio event loop as first parameter to AsyncTransport
+    t = AsyncTransport(loop, cache=None)
+    c = loop.run_until_complete(AsyncClient.create('http://webservicex.net/globalweather.asmx?wsdl', transport=t))
+
+    # Create a list of tasks to be run concurrently
+    tasks = []
+    for country in ['United Kingdom', 'Ireland', 'Canada', 'Brazil', 'Germany', 'France', 'Cyprus']:
+        tasks.append(c.service.GetCitiesByCountry(CountryName=country))
+
+    # Gather tasks into a Future, return exceptions
+    fut = asyncio.gather(*tasks, return_exceptions=True)
+
+    # Schedule a callback for when Future result is set - will be called with the Future as the sole parameter
+    fut.add_done_callback(handle_fut)
+
+    loop.run_until_complete(fut)
+    loop.run_until_complete(t.session.close())

--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -1,7 +1,7 @@
 import logging
 
-from zeep.transports import Transport
-from zeep.wsdl import Document
+from zeep.transports import Transport, AsyncTransport
+from zeep.wsdl import Document, AsyncDocument
 
 NSMAP = {
     'xsd': 'http://www.w3.org/2001/XMLSchema',
@@ -118,3 +118,27 @@ class Client(object):
 
     def get_element(self, name):
         return self.wsdl.types.get_element(name)
+
+
+class AsyncClient(Client):
+
+    def __init__(self):
+        pass
+
+    @classmethod
+    async def create(cls, wsdl, wsse=None, transport=None,
+                 service_name=None, port_name=None, plugins=None):
+        if not wsdl:
+            raise ValueError("No URL given for the wsdl")
+
+        self = AsyncClient()
+        self.transport = transport or AsyncTransport()
+        self.wsdl = await AsyncDocument.create(wsdl, self.transport)
+        self.wsse = wsse
+        self.plugins = plugins if plugins is not None else []
+
+        self._default_service = None
+        self._default_service_name = service_name
+        self._default_port_name = port_name
+
+        return self

--- a/src/zeep/parser.py
+++ b/src/zeep/parser.py
@@ -21,6 +21,13 @@ def load_external(url, transport, base_url=None):
     response = transport.load(url)
     return parse_xml(response, base_url)
 
+async def load_external_async(url, transport, base_url = None):
+    if base_url:
+        url = absolute_location(url, base_url)
+
+    response = await transport.load(url)
+    return parse_xml(response, base_url)
+
 
 def absolute_location(location, base):
     if location == base or location.startswith('intschema'):

--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -1,6 +1,7 @@
 import logging
 
 import requests
+import aiohttp
 
 from six.moves.urllib.parse import urlparse
 from zeep.cache import SqliteCache
@@ -74,3 +75,65 @@ class Transport(object):
     def get(self, address, params, headers):
         response = self.session.get(address, params=params, headers=headers)
         return response
+
+
+class AsyncTransport(Transport):
+
+    def __init__(self, loop, cache=NotSet, timeout=300, verify=True, http_auth=None):
+        self.loop = loop if loop else asyncio.get_event_loop()
+        self.cache = SqliteCache() if cache is NotSet else cache
+        self.timeout = timeout
+        self.verify = verify
+        self.http_auth = aiohttp.BasicAuth(http_auth[0], password=http_auth[1]) if http_auth else None
+        self.connector = aiohttp.TCPConnector(verify_ssl=self.verify)
+        self.headers = {'User-Agent': 'Zeep/%s (www.python-zeep.org)'.format(get_version())}
+        self.session = self.create_session()
+
+    def create_session(self):
+        return aiohttp.ClientSession(connector=self.connector, loop=self.loop, headers=self.headers, auth=self.http_auth)
+
+    async def load(self, url):
+        if not url:
+            raise ValueError("No url given to load")
+
+        scheme = urlparse(url).scheme
+        if scheme in ('http', 'https'):
+
+            if self.cache:
+                response = self.cache.get(url)
+                if response:
+                    return bytes(response)
+
+            with aiohttp.Timeout(self.timeout):
+                async with self.session.get(url) as response:
+                    response.raise_for_status()
+                    content = await response.read()
+                    if self.cache:
+                        self.cache.add(url, content)
+
+                    return content
+
+        elif scheme == 'file':
+            if url.startswith('file://'):
+                url = url[7:]
+
+        with open(url, 'rb') as fh:
+            return fh.read()
+
+    async def post(self, address, message, headers):
+        self.logger.debug("HTTP Post to %s:\n%s", address, message)
+        with aiohttp.Timeout(self.timeout):
+            response = await self.session.post(address, data=message, headers=headers)
+            self.logger.debug(
+                "HTTP Response from %s (status: %d):\n%s",
+                address, response.status_code, await response.read())
+            return response
+
+    async def post_xml(self, address, envelope, headers):
+        message = etree_to_string(envelope)
+        return await self.post(address, message, headers)
+
+    async def get(self, address, params, headers):
+        with aiohttp.Timeout(self.timeout):
+            response = await self.session.get(address, params=params, headers=headers)
+            return response

--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -127,7 +127,7 @@ class AsyncTransport(Transport):
             response = await self.session.post(address, data=message, headers=headers)
             self.logger.debug(
                 "HTTP Response from %s (status: %d):\n%s",
-                address, response.status_code, await response.read())
+                address, response.status, await response.read())
             return response
 
     async def post_xml(self, address, envelope, headers):

--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -85,6 +85,7 @@ class AsyncTransport(Transport):
         self.timeout = timeout
         self.verify = verify
         self.http_auth = aiohttp.BasicAuth(http_auth[0], password=http_auth[1]) if http_auth else None
+        self.logger = logging.getLogger(__name__)
         self.connector = aiohttp.TCPConnector(verify_ssl=self.verify)
         self.headers = {'User-Agent': 'Zeep/%s (www.python-zeep.org)'.format(get_version())}
         self.session = self.create_session()

--- a/src/zeep/wsdl/__init__.py
+++ b/src/zeep/wsdl/__init__.py
@@ -1,1 +1,1 @@
-from zeep.wsdl.wsdl import Document  # noqa
+from zeep.wsdl.wsdl import Document, AsyncDocument  # noqa

--- a/src/zeep/wsdl/wsdl.py
+++ b/src/zeep/wsdl/wsdl.py
@@ -129,6 +129,9 @@ class Document(object):
 
 class AsyncDocument(Document):
 
+    def __init__(self):
+        pass
+
     @classmethod
     async def create(cls, location, transport):
         self = AsyncDocument()

--- a/src/zeep/wsdl/wsdl.py
+++ b/src/zeep/wsdl/wsdl.py
@@ -427,10 +427,10 @@ class AsyncDefinition(Definition):
                 binding = soap.AsyncSoap11Binding.parse(self, binding_node)
             elif soap.AsyncSoap12Binding.match(binding_node):
                 binding = soap.AsyncSoap12Binding.parse(self, binding_node)
-            elif http.HttpGetBinding.match(binding_node):
-                binding = http.HttpGetBinding.parse(self, binding_node)
-            elif http.HttpPostBinding.match(binding_node):
-                binding = http.HttpPostBinding.parse(self, binding_node)
+            elif http.AsyncHttpGetBinding.match(binding_node):
+                binding = http.AsyncHttpGetBinding.parse(self, binding_node)
+            elif http.AsyncHttpPostBinding.match(binding_node):
+                binding = http.AsyncHttpPostBinding.parse(self, binding_node)
             else:
                 continue
 


### PR DESCRIPTION
As suggested in #187 

This is my first public PR, so please be gentle ;)

There are a significant amount of new classes here, because it's generally considered a bad idea to mix asynchronous and synchronous code. However, I've tried to keep the usage similar between the Client and the new AsyncClient where possible. I've also tried to inherit from existing classes to minimise impact, where it seemed logical to do so.

The major difference is that to instantiate the AsyncClient, you need to run AsyncClient.create() which is both a coroutine and a classmethod and returns the client instance. This my preferred way of working around the need to await coroutines in **init**() (see [](http://stackoverflow.com/a/33134213/5567657)). 

Once your AsyncClient is instantiated, you can call client.service.operation() as normal, but this is now a coroutine which needs to be awaited. I've included an example showing usage (examples/async_example.py).

There are however a few caveats of which I'm aware:
- I've used the async/await syntax which is only available from Python 3.5. This may not jive well with you as the rest of the project seems to strive for compatibility.
- Owing to my relative lack of experience with pytest, I haven't written any tests for this. Invite others with more experience to do so...?
