### PR TITLE
Make etree.cleanup_namespaces call possible for lxml < 3.5.x

### DIFF
--- a/src/zeep/wsa.py
+++ b/src/zeep/wsa.py
@@ -24,9 +24,12 @@ class WsAddressingPlugin(Plugin):
             WSA.To(binding_options['address']),
         ]
         header.extend(headers)
-        etree.cleanup_namespaces(
-            envelope, top_nsmap={
-                'wsa': 'http://www.w3.org/2005/08/addressing'
-            })
+        try:
+            etree.cleanup_namespaces(
+                envelope, top_nsmap={
+                    'wsa': 'http://www.w3.org/2005/08/addressing'
+                })
+        except TypeError:
+            etree.cleanup_namespaces(envelope)
 
         return envelope, http_headers


### PR DESCRIPTION
This fixes #197.

My first try was introspecting cleanup_namespaces to check the call signature for the 'top_nsmap' argument. However, it turned out that older (I tried 3.3.5) versions of lxml have a pure c implementation of this method that cannot be introspected, so I had to fall back to try-except.

I cannot oversee if just leaving out the top_nsmap argument does make any sense though.