### PR TITLE
Add a null check on the message result

### DIFF
--- a/src/zeep/wsdl/messages/soap.py
+++ b/src/zeep/wsdl/messages/soap.py
@@ -83,7 +83,9 @@ class SoapMessage(ConcreteMessage):
             return result
 
         result = result.body
-        if len(result) > 1:
+        if result is None:
+            return None
+        elif len(result) > 1:
             return result
         elif len(result) == 0:
             return None


### PR DESCRIPTION
Currently len() is done before checking whether the message result is None.