### PR TITLE
Gracefully handle exceptions for unsupported Binding types

### DIFF
--- a/src/zeep/wsdl/wsdl.py
+++ b/src/zeep/wsdl/wsdl.py
@@ -340,19 +340,23 @@ class Definition(object):
         result = {}
         for binding_node in doc.findall('wsdl:binding', namespaces=NSMAP):
             # Detect the binding type
-            if bindings.Soap11Binding.match(binding_node):
-                binding = bindings.Soap11Binding.parse(self, binding_node)
-            elif bindings.Soap12Binding.match(binding_node):
-                binding = bindings.Soap12Binding.parse(self, binding_node)
-            elif bindings.HttpGetBinding.match(binding_node):
-                binding = bindings.HttpGetBinding.parse(self, binding_node)
-            elif bindings.HttpPostBinding.match(binding_node):
-                binding = bindings.HttpPostBinding.parse(self, binding_node)
-            else:
+            try:
+                if bindings.Soap11Binding.match(binding_node):
+                    binding = bindings.Soap11Binding.parse(self, binding_node)
+                elif bindings.Soap12Binding.match(binding_node):
+                    binding = bindings.Soap12Binding.parse(self, binding_node)
+                elif bindings.HttpGetBinding.match(binding_node):
+                    binding = bindings.HttpGetBinding.parse(self, binding_node)
+                elif bindings.HttpPostBinding.match(binding_node):
+                    binding = bindings.HttpPostBinding.parse(self, binding_node)
+                else:
+                    continue
+            except NotImplementedError:
+                logger.warn("Binding not implemented: %s", str(binding_node))
                 continue
-
-            logger.debug("Adding binding: %s", binding.name.text)
-            result[binding.name.text] = binding
+            else:
+                logger.debug("Adding binding: %s", binding.name.text)
+                result[binding.name.text] = binding
         return result
 
     def parse_service(self, doc):


### PR DESCRIPTION
I have a WSDL with multiple binding for the same service. One binding type is supported (http), and the other(net.tcp), an alternate access for the same set of services, is not supported. Pointing zeep at this WSDL causes an exception which propagates upwards.. Suggest catching this unsupported exception, thus only mapping the supported bindings, and ignoring the others..
Stack trace, before..

```
$ python3 -mzeep XXX_raw.wsdl 
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/zeep/__main__.py", line 85, in <module>
    main(args)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/zeep/__main__.py", line 74, in main
    client = Client(args.wsdl_file, transport=transport)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/zeep/client.py", line 52, in __init__
    self.wsdl = Document(wsdl, self.transport)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/zeep/wsdl/wsdl.py", line 61, in __init__
    root_definitions = Definition(self, document, self.location)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/zeep/wsdl/wsdl.py", line 157, in __init__
    self.bindings = self.parse_binding(doc)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/zeep/wsdl/wsdl.py", line 346, in parse_binding
    binding = bindings.Soap12Binding.parse(self, binding_node)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/zeep/wsdl/bindings/soap.py", line 185, in parse
    raise NotImplementedError("Only soap/http is supported for now")
NotImplementedError: Only soap/http is supported for now
```