### PR TITLE
Fixes #232: Wrap children of an array in the appropriate element

### DIFF
--- a/src/zeep/xsd/elements.py
+++ b/src/zeep/xsd/elements.py
@@ -131,6 +131,11 @@ class Any(Base):
                     node = etree.SubElement(parent, 'item')
                     node.set(xsi_ns('type'), self.restrict.qname)
                     self._render_value_item(node, val)
+            elif self.restrict:
+                for val in value:
+                    node = etree.SubElement(parent, self.restrict.name)
+                    # node.set(xsi_ns('type'), self.restrict.qname)
+                    self._render_value_item(node, val)
             else:
                 for val in value:
                     self._render_value_item(parent, val)

--- a/tests/test_wsdl_arrays.py
+++ b/tests/test_wsdl_arrays.py
@@ -111,3 +111,60 @@ def test_complex_type():
         </document>
     """
     assert_nodes_equal(expected, node)
+
+
+def test_complex_type_without_name():
+    schema = xsd.Schema(load_xml("""
+    <xsd:schema
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+        xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+        xmlns:tns="http://tests.python-zeep.org/tns"
+        targetNamespace="http://tests.python-zeep.org/tns">
+      <xsd:import namespace="http://schemas.xmlsoap.org/soap/encoding/"/>
+
+      <xsd:complexType name="ArrayObject">
+        <xsd:sequence>
+          <xsd:element name="attr_1" type="xsd:string"/>
+          <xsd:element name="attr_2" type="xsd:string"/>
+        </xsd:sequence>
+      </xsd:complexType>
+      <xsd:complexType name="ArrayOfObject">
+        <xsd:complexContent>
+          <xsd:restriction base="SOAP-ENC:Array">
+            <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:ArrayObject[]"/>
+          </xsd:restriction>
+        </xsd:complexContent>
+      </xsd:complexType>
+    </xsd:schema>
+    """), transport=get_transport())
+
+    ArrayOfObject = schema.get_type('ns0:ArrayOfObject')
+    ArrayObject = schema.get_type('ns0:ArrayObject')
+
+    value = ArrayOfObject([
+        ArrayObject(attr_1='attr-1', attr_2='attr-2'),
+        ArrayObject(attr_1='attr-3', attr_2='attr-4'),
+        ArrayObject(attr_1='attr-5', attr_2='attr-6'),
+    ])
+
+    node = etree.Element('document')
+    ArrayOfObject.render(node, value)
+
+    expected = """
+        <document>
+            <ArrayObject>
+                <attr_1>attr-1</attr_1>
+                <attr_2>attr-2</attr_2>
+            </ArrayObject>
+            <ArrayObject>
+                <attr_1>attr-3</attr_1>
+                <attr_2>attr-4</attr_2>
+            </ArrayObject>
+            <ArrayObject>
+                <attr_1>attr-5</attr_1>
+                <attr_2>attr-6</attr_2>
+            </ArrayObject>
+        </document>
+    """
+    assert_nodes_equal(expected, node)

--- a/tests/test_xsd_integration.py
+++ b/tests/test_xsd_integration.py
@@ -635,10 +635,14 @@ def test_wsdl_array_type():
     expected = """
         <document>
             <ns0:array xmlns:ns0="http://tests.python-zeep.org/">
-                <ns0:item_1>foo_1</ns0:item_1>
-                <ns0:item_2>bar_1</ns0:item_2>
-                <ns0:item_1>foo_2</ns0:item_1>
-                <ns0:item_2>bar_2</ns0:item_2>
+                <base>
+                    <ns0:item_1>foo_1</ns0:item_1>
+                    <ns0:item_2>bar_1</ns0:item_2>
+                </base>
+                <base>
+                    <ns0:item_1>foo_2</ns0:item_1>
+                    <ns0:item_2>bar_2</ns0:item_2>
+                </base>
             </ns0:array>
         </document>
     """


### PR DESCRIPTION
I also changed an existing test that failed after the code changes, but the expected result looked incorrect to me. Hence, I changed that test as well.