### PR TITLE
ListType should inherit from SimpleType

### DIFF
--- a/src/zeep/xsd/types.py
+++ b/src/zeep/xsd/types.py
@@ -506,7 +506,7 @@ class ComplexType(Type):
         return value
 
 
-class ListType(Type):
+class ListType(SimpleType):
     """Space separated list of simpleType values"""
 
     def __init__(self, item_type):


### PR DESCRIPTION
The list element has a parent element of SimpleType, not Type.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>

I was uncertain on how to best provide a type-inheritance test for the list type.