### PR TITLE
Remove Redundant Headers

### DIFF
--- a/src/zeep/wsdl/messages/soap.py
+++ b/src/zeep/wsdl/messages/soap.py
@@ -302,6 +302,10 @@ class SoapMessage(ConcreteMessage):
         else:
             raise ValueError("Invalid value given to _soapheaders")
 
+        # remove redundant headers
+        for x in header:
+            if len(x) == 0 and x.text is None:
+                x.getparent().remove(x)
         return header
 
     def _deserialize_headers(self, xmlelement):

--- a/src/zeep/wsdl/messages/soap.py
+++ b/src/zeep/wsdl/messages/soap.py
@@ -304,7 +304,7 @@ class SoapMessage(ConcreteMessage):
 
         # remove redundant headers
         for x in header:
-            if len(x) == 0 and x.text is None:
+            if len(x) == 0 and x.text is None and len(x.attrib) == 0:
                 x.getparent().remove(x)
         return header
 

--- a/src/zeep/wsdl/messages/soap.py
+++ b/src/zeep/wsdl/messages/soap.py
@@ -302,7 +302,7 @@ class SoapMessage(ConcreteMessage):
         else:
             raise ValueError("Invalid value given to _soapheaders")
 
-        # remove redundant headers
+        # remove redundant headers that have no child nodes, text or attributes
         for x in header:
             if len(x) == 0 and x.text is None and len(x.attrib) == 0:
                 x.getparent().remove(x)

--- a/tests/test_wsdl.py
+++ b/tests/test_wsdl.py
@@ -98,10 +98,6 @@ def test_parse_soap_header_wsdl():
                     'username': 'ikke',
                     'password': 'oeh-is-geheim!',
                 },
-                'header2': {
-                    'username': 'ikke',
-                    'password': 'oeh-is-geheim!',
-                }
             })
 
         assert result == 120.123
@@ -117,10 +113,6 @@ def test_parse_soap_header_wsdl():
                  <username>ikke</username>
                  <password>oeh-is-geheim!</password>
               </ns0:Authentication>
-              <ns1:Authentication2 xmlns:ns1="http://example.com/stockquote.xsd">
-                 <username>ikke</username>
-                 <password>oeh-is-geheim!</password>
-              </ns1:Authentication2>
            </soap-env:Header>
            <soap-env:Body>
               <ns0:TradePriceRequest xmlns:ns0="http://example.com/stockquote.xsd">

--- a/tests/test_wsdl.py
+++ b/tests/test_wsdl.py
@@ -97,7 +97,7 @@ def test_parse_soap_header_wsdl():
                 'header': {
                     'username': 'ikke',
                     'password': 'oeh-is-geheim!',
-                },
+                }
             })
 
         assert result == 120.123

--- a/tests/test_wsdl.py
+++ b/tests/test_wsdl.py
@@ -97,6 +97,10 @@ def test_parse_soap_header_wsdl():
                 'header': {
                     'username': 'ikke',
                     'password': 'oeh-is-geheim!',
+                },
+                'header2': {
+                    'username': 'ikke',
+                    'password': 'oeh-is-geheim!',
                 }
             })
 
@@ -113,6 +117,10 @@ def test_parse_soap_header_wsdl():
                  <username>ikke</username>
                  <password>oeh-is-geheim!</password>
               </ns0:Authentication>
+              <ns1:Authentication2 xmlns:ns1="http://example.com/stockquote.xsd">
+                 <username>ikke</username>
+                 <password>oeh-is-geheim!</password>
+              </ns1:Authentication2>
            </soap-env:Header>
            <soap-env:Body>
               <ns0:TradePriceRequest xmlns:ns0="http://example.com/stockquote.xsd">

--- a/tests/wsdl_files/soap_header.wsdl
+++ b/tests/wsdl_files/soap_header.wsdl
@@ -31,10 +31,19 @@
           </sequence>
         </complexType>
       </element>
+        <element name="Authentication2">
+            <complexType>
+                <sequence>
+                    <element name="username" type="string"/>
+                    <element name="password" type="string"/>
+                </sequence>
+            </complexType>
+        </element>
     </schema>
   </types>
   <message name="GetLastTradePriceInput">
     <part name="header" element="xsd1:Authentication"/>
+      <part name="header2" element="xsd1:Authentication2"/>
     <part name="body" element="xsd1:TradePriceRequest"/>
   </message>
   <message name="GetLastTradePriceOutput">
@@ -52,6 +61,7 @@
       <soap:operation soapAction="http://example.com/GetLastTradePrice"/>
       <input>
         <soap:header message="tns:GetLastTradePriceInput" part="header" use="literal"/>
+          <soap:header message="tns:GetLastTradePriceInput" part="header2" use="literal"/>
         <soap:body use="literal"/>
       </input>
       <output>

--- a/tests/wsdl_files/soap_header.wsdl
+++ b/tests/wsdl_files/soap_header.wsdl
@@ -31,19 +31,18 @@
           </sequence>
         </complexType>
       </element>
-        <element name="Authentication2">
-            <complexType>
-                <sequence>
-                    <element name="username" type="string"/>
-                    <element name="password" type="string"/>
-                </sequence>
+        <element name="TokenAuthentication">
+          <complexType>
+            <all>
+              <element name="token" type="string"/>
+            </all>
             </complexType>
         </element>
     </schema>
   </types>
   <message name="GetLastTradePriceInput">
     <part name="header" element="xsd1:Authentication"/>
-      <part name="header2" element="xsd1:Authentication2"/>
+    <part name="token" element="xsd1:TokenAuthentication"/>
     <part name="body" element="xsd1:TradePriceRequest"/>
   </message>
   <message name="GetLastTradePriceOutput">
@@ -61,7 +60,7 @@
       <soap:operation soapAction="http://example.com/GetLastTradePrice"/>
       <input>
         <soap:header message="tns:GetLastTradePriceInput" part="header" use="literal"/>
-          <soap:header message="tns:GetLastTradePriceInput" part="header2" use="literal"/>
+        <soap:header message="tns:GetLastTradePriceInput" part="token" use="literal"/>
         <soap:body use="literal"/>
       </input>
       <output>


### PR DESCRIPTION
When creating a SOAP request and the request accepts multiple headers, if the user specifies only some of the headers in _soapheaders field, this library generates empty tags for all unspecified headers. These empty headers can sometimes cause problems with some clients. As a result a check is now made to remove headers that have no content.