### PR TITLE
Fix for #264

### DIFF
--- a/src/zeep/xsd/builtins.py
+++ b/src/zeep/xsd/builtins.py
@@ -89,7 +89,7 @@ class _BuiltinType(SimpleType):
         super(_BuiltinType, self).__init__(
             qname or etree.QName(self._default_qname), is_global)
 
-    def signature(self, depth=0):
+    def signature(self, depth=()):
         if self.qname.namespace == NS_XSD:
             return 'xsd:%s' % self.name
         return self.name

--- a/src/zeep/xsd/elements.py
+++ b/src/zeep/xsd/elements.py
@@ -43,7 +43,7 @@ class Base(object):
         """Consume matching xmlelements and call parse() on each of them"""
         raise NotImplementedError()
 
-    def signature(self, depth=0):
+    def signature(self, depth=()):
         return ''
 
 
@@ -188,7 +188,7 @@ class Any(Base):
     def resolve(self):
         return self
 
-    def signature(self, depth=0):
+    def signature(self, depth=()):
         if self.restrict:
             base = self.restrict.name
         else:
@@ -360,8 +360,8 @@ class Element(Base):
         self.resolve_type()
         return self
 
-    def signature(self, depth=0):
-        if depth > 0 and self.is_global:
+    def signature(self, depth=()):
+        if len(depth) > 0 and self.is_global:
             return self.name + '()'
 
         value = self.type.signature(depth)
@@ -433,7 +433,7 @@ class AttributeGroup(Element):
         self._attributes = resolved
         return self
 
-    def signature(self, depth=0):
+    def signature(self, depth=()):
         return ', '.join(attr.signature() for attr in self._attributes)
 
 
@@ -457,7 +457,7 @@ class AnyAttribute(Base):
         for name, val in value.items():
             parent.set(name, val)
 
-    def signature(self, depth=0):
+    def signature(self, depth=()):
         return '{}'
 
 

--- a/src/zeep/xsd/indicators.py
+++ b/src/zeep/xsd/indicators.py
@@ -188,11 +188,17 @@ class OrderIndicator(Indicator, list):
                 if element_value is not None or not element.is_optional:
                     element.render(parent, element_value)
 
-    def signature(self, depth=0):
-        depth += 1
+    def signature(self, depth=()):
+        """
+        Use a tuple of element names as depth indicator, so that when an element is repeated,
+        do not try to create its signature, as it would lead to infinite recursion
+        """
+        depth += (self.name,)
         parts = []
         for name, element in self.elements_nested:
-            if name:
+            if hasattr(element, 'type') and element.type.name and element.type.name in depth:
+                parts.append('{}: {}'.format(name, element.type.name))
+            elif name:
                 parts.append('%s: %s' % (name, element.signature(depth)))
             elif isinstance(element,  Indicator):
                 parts.append('%s' % (element.signature(depth)))
@@ -201,7 +207,7 @@ class OrderIndicator(Indicator, list):
         part = ', '.join(parts)
 
         if self.accepts_multiple:
-            return '[%s]' % (part)
+            return '[%s]' % (part,)
         return part
 
 
@@ -436,7 +442,7 @@ class Choice(OrderIndicator):
             matches = sorted(matches, key=operator.itemgetter(0), reverse=True)
             return matches[0][1:]
 
-    def signature(self, depth=0):
+    def signature(self, depth=()):
         parts = []
         for name, element in self.elements_nested:
             if isinstance(element, OrderIndicator):
@@ -445,7 +451,7 @@ class Choice(OrderIndicator):
                 parts.append('{%s: %s}' % (name, element.signature(depth)))
         part = '(%s)' % ' | '.join(parts)
         if self.accepts_multiple:
-            return '%s[]' % (part)
+            return '%s[]' % (part,)
         return part
 
 
@@ -555,5 +561,5 @@ class Group(Indicator):
         self.child = self.child.resolve()
         return self
 
-    def signature(self, depth=0):
+    def signature(self, depth=()):
         return self.child.signature(depth)

--- a/src/zeep/xsd/types.py
+++ b/src/zeep/xsd/types.py
@@ -68,7 +68,7 @@ class Type(object):
         return []
 
     @classmethod
-    def signature(cls, depth=0):
+    def signature(cls, depth=()):
         return ''
 
 
@@ -182,7 +182,7 @@ class SimpleType(Type):
     def resolve(self):
         return self
 
-    def signature(self, depth=0):
+    def signature(self, depth=()):
         return self.name
 
     def xmlvalue(self, value):
@@ -503,12 +503,12 @@ class ComplexType(Type):
             qname=self.qname)
         return new.resolve()
 
-    def signature(self, depth=0):
-        if depth > 0 and self.is_global:
+    def signature(self, depth=()):
+        if len(depth) > 0 and self.is_global:
             return self.name
 
         parts = []
-        depth += 1
+        depth += (self.name,)
         for name, element in self.elements_nested:
             # http://schemas.xmlsoap.org/soap/encoding/ contains cyclic type
             if isinstance(element, Element) and element.type == self:
@@ -522,7 +522,7 @@ class ComplexType(Type):
             parts.append(part)
 
         value = ', '.join(parts)
-        if depth > 1:
+        if len(depth) > 1:
             value = '{%s}' % value
         return value
 
@@ -555,7 +555,7 @@ class ListType(SimpleType):
         item_type = self.item_type
         return [item_type.pythonvalue(v) for v in value.split()]
 
-    def signature(self, depth=0):
+    def signature(self, depth=()):
         return self.item_type.signature(depth) + '[]'
 
 
@@ -576,7 +576,7 @@ class UnionType(SimpleType):
             self.item_class = base_class
         return self
 
-    def signature(self, depth=0):
+    def signature(self, depth=()):
         return ''
 
     def parse_xmlelement(self, xmlelement, schema=None, allow_none=True,


### PR DESCRIPTION
I propose to fix this bug by using a tuple of element names as a depth parameter in signature method, instead of an integer. So not only we know how deep in recursion we are, but also for what elements signature was already created.