### PR TITLE
Enables custom HTTP headers to be passed to the Transport for each request.

### DIFF
--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -14,7 +14,7 @@ class Transport(object):
     supports_async = False
 
     def __init__(self, cache=NotSet, timeout=300, operation_timeout=None,
-                 verify=True, http_auth=None):
+                 verify=True, http_auth=None, http_headers={}):
         """The transport object handles all communication to the SOAP server.
 
         :param cache: The cache object to be used to cache GET requests
@@ -36,6 +36,7 @@ class Transport(object):
         self.http_headers = {
             'User-Agent': 'Zeep/%s (www.python-zeep.org)' % (get_version())
         }
+        self.http_headers.update(http_headers)
         self.session = self.create_session()
 
     def create_session(self):


### PR DESCRIPTION
This pull request enables the user to specify custom HTTP headers in a dict when creating a Transport object. It would also enable the user to override the default user-agent if necessary. 

I use this in a project where the device requires a specific User-Agent and Cookie header in order to access the SOAP API.

I understand this may be a niche requirement, but thought I'd put up a pull request just incase anyone else thought it was a good idea for the project.