### PR TITLE
Multipart response support

### DIFF
--- a/docs/multipart.rst
+++ b/docs/multipart.rst
@@ -1,0 +1,25 @@
+======================================
+Multipart support for SOAP Attachments
+======================================
+
+If the server responds with a Content-type: multipart, the code will process
+the parts individually and return a list of objects. Typically this will be
+a ``BodyPart`` object from request_toolbelt.
+
+The ``BodyPart`` object is a ``Response``-like object to an individual
+subpart of a multipart response.
+
+Example based on https://www.w3.org/TR/SOAP-attachments
+
+.. code-block:: python
+
+    from zeep import Client
+
+    client = Client('http://www.risky-stuff.com/claim.svc?wsdl')
+
+    parts = client.service.GetClaimDetails('061400a')
+
+    ClaimDetails = parts[0]
+    SignedFormTiffImage = parts[1].content
+    CrashPhotoJpeg = parts[2].content
+

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ with open('README.rst') as fh:
 
 setup(
     name='zeep',
-    version='0.24.0',
+    version='0.24.0.1',
     description='A modern/fast Python SOAP client based on lxml / requests',
     long_description=long_description,
     author="Michael van Tellingen",

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ install_requires = [
     'requests>=2.7.0',
     'six>=1.9.0',
     'pytz',
+    'requests_toolbelt',
 ]
 
 docs_require = [
@@ -37,7 +38,7 @@ with open('README.rst') as fh:
 
 setup(
     name='zeep',
-    version='0.24.0.1',
+    version='0.24.0.2',
     description='A modern/fast Python SOAP client based on lxml / requests',
     long_description=long_description,
     author="Michael van Tellingen",

--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -115,7 +115,7 @@ class SoapBinding(Binding):
         operation_obj = self.get(operation)
         return self.process_reply(client, operation_obj, response)
 
-    def process_reply(self, client, operation, response):
+    def process_xml_reply(self, client, operation, response):
         """Process the XML reply from the server.
 
         :param client: The client with which the operation was called
@@ -124,17 +124,7 @@ class SoapBinding(Binding):
         :type operation: zeep.wsdl.definitions.Operation
         :param response: The response object returned by the remote server
         :type response: requests.Response
-
         """
-        if response.status_code != 200 and not response.content:
-            raise TransportError(
-                u'Server returned HTTP status %d (no content available)'
-                % response.status_code)
-
-        if re.match("multipart", response.headers['Content-Type']):
-            multipart = requests_toolbelt.multipart.decoder.MultipartDecoder.from_response(response)
-            part = multipart.parts[1]
-            return part
 
         try:
             doc = parse_xml(response.content, recover=True)
@@ -157,6 +147,39 @@ class SoapBinding(Binding):
             return self.process_error(doc, operation)
 
         return operation.process_reply(doc)
+
+    def process_reply(self, client, operation, response):
+        """Process the reply from the server, handle Multipart if needed
+
+        :param client: The client with which the operation was called
+        :type client: zeep.client.Client
+        :param operation: The operation object from which this is a reply
+        :type operation: zeep.wsdl.definitions.Operation
+        :param response: The response object returned by the remote server
+        :type response: requests.Response
+
+        """
+        if response.status_code != 200 and not response.content:
+            raise TransportError(
+                u'Server returned HTTP status %d (no content available)'
+                % response.status_code)
+
+        if 'Content-Type' in response.headers:
+            if re.match("multipart", response.headers['Content-Type']):
+                multipart = requests_toolbelt.multipart.decoder.MultipartDecoder.from_response(response)
+
+                parts = []
+                for part in multipart.parts:
+                    if 'Content-Type' in part.headers:
+                        if re.match("text/xml", part.headers['Content-Type']):
+                            setattr(part, 'status_code', response.status_code)
+                            newpart = self.process_xml_reply(client, operation, part)
+                            if newpart: # if above xml processing is not working, only use if data is returned
+                                part = newpart
+                    parts.append(part)
+                return parts
+
+        return self.process_xml_reply(client, operation, response)
 
     def process_error(self, doc, operation):
         raise NotImplementedError

--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -2,6 +2,7 @@ import logging
 
 import re
 import requests_toolbelt
+from requests.structures import CaseInsensitiveDict
 
 from lxml import etree
 
@@ -170,6 +171,8 @@ class SoapBinding(Binding):
 
                 parts = []
                 for part in multipart.parts:
+                    headers = ( (k.decode(multipart.encoding), v.decode(multipart.encoding)) for k, v in part.headers.items())
+                    part.headers = CaseInsensitiveDict(headers)
                     if 'Content-Type' in part.headers:
                         if re.match("text/xml", part.headers['Content-Type']):
                             setattr(part, 'status_code', response.status_code)

--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -1,5 +1,8 @@
 import logging
 
+import re
+import requests_toolbelt
+
 from lxml import etree
 
 from zeep import plugins, wsa
@@ -127,6 +130,11 @@ class SoapBinding(Binding):
             raise TransportError(
                 u'Server returned HTTP status %d (no content available)'
                 % response.status_code)
+
+        if re.match("multipart", response.headers['Content-Type']):
+            multipart = requests_toolbelt.multipart.decoder.MultipartDecoder.from_response(response)
+            part = multipart.parts[1]
+            return part
 
         try:
             doc = parse_xml(response.content, recover=True)

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1,0 +1,56 @@
+
+import pytest
+import requests_mock
+from zeep import Client
+from zeep.transports import Transport
+
+transport = Transport()
+client = Client('tests/wsdl_files/claim.wsdl', transport=transport)
+
+data = "\r\n".join("""
+--MIME_boundary
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-ID: <claim061400a.xml@claiming-it.com>
+
+<?xml version='1.0' ?>
+<SOAP-ENV:Envelope
+xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+<SOAP-ENV:Body>
+<claim:insurance_claim_auto id="insurance_claim_document_id"
+xmlns:claim="http://schemas.risky-stuff.com/Auto-Claim">
+<theSignedForm href="cid:claim061400a.tiff@claiming-it.com"/>
+<theCrashPhoto href="cid:claim061400a.jpeg@claiming-it.com"/>
+<!-- ... more claim details go here... -->
+</claim:insurance_claim_auto>
+</SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+
+--MIME_boundary
+Content-Type: image/tiff
+Content-Transfer-Encoding: base64
+Content-ID: <claim061400a.tiff@claiming-it.com>
+
+...Base64 encoded TIFF image...
+--MIME_boundary
+Content-Type: image/jpeg
+Content-Transfer-Encoding: binary
+Content-ID: <claim061400a.jpeg@claiming-it.com>
+
+...Raw JPEG image..
+--MIME_boundary--
+
+""".splitlines()).encode('utf-8')
+
+@pytest.mark.requests
+def test_multipart():
+    with requests_mock.Mocker() as m:
+        m.post('https://www.risky-stuff.com/claim.svc',
+               headers= {'Content-Type': 'multipart/related; type="text/xml"; start="<claim061400a.xml@claiming-it.com>"; boundary="MIME_boundary"'},
+               content=data
+               )
+        parts = client.service.GetClaimDetails('061400a')
+
+        assert parts[0].headers['Content-ID'] == "<claim061400a.xml@claiming-it.com>"
+        assert parts[1].headers['Content-ID'] == "<claim061400a.tiff@claiming-it.com>"
+        assert parts[2].headers['Content-ID'] == "<claim061400a.jpeg@claiming-it.com>"

--- a/tests/wsdl_files/claim.wsdl
+++ b/tests/wsdl_files/claim.wsdl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+    name="ClaimService"
+    targetNamespace="http://risky-stuff.com/soap/GetClaimDetails/"
+    xmlns="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:tns="http://risky-stuff.com/soap/GetClaimDetails/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <types>
+        <schema elementFormDefault="qualified"
+            targetNamespace="http://risky-stuff.com/soap/GetClaimDetails/"
+            xmlns="http://www.w3.org/2001/XMLSchema"
+            xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+            xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+            <simpleType name="ClaimID">
+                <restriction base="string"/>
+            </simpleType>
+        </schema>
+    </types>
+    <message name="GetClaimDetailsInput">
+    <part name="ClaimID" type="tns:ClaimID"/>
+    </message>
+    <message name="GetClaimDetailsOutput"/>
+    <portType name="GetClaimDetailsPortType">
+        <operation name="GetClaimDetails">
+            <input message="tns:GetClaimDetailsInput"/>
+            <output message="tns:GetClaimDetailsOutput"/>
+        </operation>
+    </portType>
+    <binding name="GetClaimDetailsBinding" type="tns:GetClaimDetailsPortType">
+        <soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="GetClaimDetails">
+            <soap:operation soapAction="http://schemas.risk-stuff.com/soap/action/#GetClaimDetails"/>
+                <input>
+                    <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="http://schemas.risk-stuff.com/soap/" use="encoded"/>
+                </input>
+                <output>
+                    <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="http://schemas.risk-stuff.com/soap/" use="encoded"/>
+                </output>
+        </operation>
+    </binding>
+    <service name="GetClaimDetailsService">
+        <port binding="tns:GetClaimDetailsBinding" name="GetClaimDetailsPort">
+            <soap:address location="https://www.risky-stuff.com/claim.svc"/>
+        </port>
+    </service>
+</definitions>


### PR DESCRIPTION
Added support for multipart responses for SOAP attachments. This works for file attachments. If a multipart is text/xml, it seems the xml processing is not working correctly for some reason.

The returned object is a list of parts from the multipart decoder.
