### PR TITLE
Add xml_huge_tree option to client, to allow very large XML responses.

### DIFF
--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -108,12 +108,15 @@ class Client(object):
                       first port defined in the service element in the WSDL
                       document.
     :param plugins: a list of Plugin instances
+    :param xml_huge_tree: disable lxml/libxml2 security restrictions and
+                          support very deep trees and very long text content
 
 
     """
 
     def __init__(self, wsdl, wsse=None, transport=None,
-                 service_name=None, port_name=None, plugins=None, strict=True):
+                 service_name=None, port_name=None, plugins=None,
+                 strict=True, xml_huge_tree=False):
         if not wsdl:
             raise ValueError("No URL given for the wsdl")
 
@@ -121,6 +124,7 @@ class Client(object):
         self.wsdl = Document(wsdl, self.transport, strict=strict)
         self.wsse = wsse
         self.plugins = plugins if plugins is not None else []
+        self.xml_huge_tree = xml_huge_tree
 
         # options
         self.raw_response = False

--- a/src/zeep/loader.py
+++ b/src/zeep/loader.py
@@ -18,7 +18,8 @@ class ImportResolver(etree.Resolver):
             return self.resolve_string(content, context)
 
 
-def parse_xml(content, transport, base_url=None, strict=True):
+def parse_xml(content, transport, base_url=None, strict=True,
+              xml_huge_tree=False):
     """Parse an XML string and return the root Element.
 
     :param content: The XML string
@@ -31,14 +32,16 @@ def parse_xml(content, transport, base_url=None, strict=True):
     :param strict: boolean to indicate if the lxml should be parsed a 'strict'.
       If false then the recover mode is enabled which tries to parse invalid
       XML as best as it can.
+    :param xml_huge_tree: boolean to indicate if lxml should process very
+      large XML content.
     :type strict: boolean
     :returns: The document root
     :rtype: lxml.etree._Element
 
     """
     recover = not strict
-    parser = etree.XMLParser(
-        remove_comments=True, resolve_entities=False, recover=recover)
+    parser = etree.XMLParser(remove_comments=True, resolve_entities=False,
+                             recover=recover, huge_tree=xml_huge_tree)
     parser.resolvers.add(ImportResolver(transport))
     try:
         return fromstring(content, parser=parser, base_url=base_url)

--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -150,7 +150,7 @@ class SoapBinding(Binding):
             content = response.content
 
         try:
-            doc = parse_xml(content, self.transport)
+            doc = parse_xml(content, self.transport, xml_huge_tree=client.xml_huge_tree)
         except XMLSyntaxError:
             raise TransportError(
                 u'Server returned HTTP status %d (%s)'

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,14 @@
+from zeep.loader import parse_xml
+from tests.utils import DummyTransport
+
+def test_huge_text():
+    # libxml2>=2.7.3 has XML_MAX_TEXT_LENGTH 10000000 without XML_PARSE_HUGE
+    tree = parse_xml(u"""
+        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+         <s:Body>
+          <HugeText xmlns="http://hugetext">%s</HugeText>
+         </s:Body>
+        </s:Envelope>
+    """ % (u'\u00e5' * 10000001), DummyTransport(), xml_huge_tree=True)
+
+    assert tree[0][0].text == u'\u00e5' * 10000001


### PR DESCRIPTION
I have looked into switching from suds-jurko to zeep. One issue I came across was with very large responses.

In older versions (before 9ff52c8e1?) they where silently truncated. Now they give
```zeep.exceptions.XMLSyntaxError: Invalid XML content received (xmlSAX2Characters: huge text node, line 4, column 5000144)```

I found the reason to be security features in libxml2, this PR adds an option to disable them.