### PR TITLE
Fix exception referenced before assignment when decode SOAP Multipart

### DIFF
--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -132,6 +132,7 @@ class SoapBinding(Binding):
 
         content_type = response.headers.get('Content-Type', 'text/xml')
         media_type = get_media_type(content_type)
+        message_pack = None
 
         if media_type == 'multipart/related':
             decoder = MultipartDecoder(
@@ -142,7 +143,6 @@ class SoapBinding(Binding):
                 message_pack = MessagePack(parts=decoder.parts[1:])
         else:
             content = response.content
-            message_pack = None
 
         try:
             doc = parse_xml(content)


### PR DESCRIPTION
If there is only one part in multipart result, it will cause exception 
`UnboundLocalError: local variable 'message_pack' referenced before assignment`

Move `message_pack` for initialization
