### PR TITLE
set default encoding utf-8 for wsdl attachments headers

### DIFF
--- a/src/zeep/wsdl/attachments.py
+++ b/src/zeep/wsdl/attachments.py
@@ -49,8 +49,9 @@ class MessagePack(object):
 
 class Attachment(object):
     def __init__(self, part):
+        encoding = part.encoding or 'utf-8'
         self.headers = CaseInsensitiveDict({
-            k.decode(part.encoding): v.decode(part.encoding)
+            k.decode(encoding): v.decode(encoding)
             for k, v in part.headers.items()
         })
         self.content_type = self.headers.get('Content-Type', None)


### PR DESCRIPTION
Fix the issue if `part.encoding` is None will cause header string decode() exception

should get default encoding as `utf-8` if `part.encoding` is None