### PR TITLE
Fix: Impossible to initialize async instance if loop currently running

### DIFF
--- a/src/zeep/asyncio/transport.py
+++ b/src/zeep/asyncio/transport.py
@@ -6,8 +6,8 @@ import asyncio
 import logging
 
 import aiohttp
-import requests.cookies
 import requests.auth
+import requests.cookies
 from requests import Response
 
 from zeep.transports import Transport

--- a/src/zeep/asyncio/transport.py
+++ b/src/zeep/asyncio/transport.py
@@ -65,6 +65,9 @@ class AsyncTransport(Transport):
                         password=password
                     )
 
+                # SSL verification settings copy
+                session.verify = self.session.connector.verify_ssl
+
                 # Standard sync logic
                 response = session.get(url, timeout=self.load_timeout)
                 response.raise_for_status()

--- a/tests/test_asyncio_transport.py
+++ b/tests/test_asyncio_transport.py
@@ -1,5 +1,7 @@
+from asyncio import coroutine
 import pytest
 from pretend import stub
+import requests_mock
 from lxml import etree
 from aioresponses import aioresponses
 
@@ -20,6 +22,23 @@ def test_load(event_loop):
     with aioresponses() as m:
         m.get('http://tests.python-zeep.org/test.xml', body='x')
         result = transport.load('http://tests.python-zeep.org/test.xml')
+        assert result == b'x'
+
+
+@pytest.mark.requests
+@pytest.mark.asyncio
+def test_load_sync(event_loop):
+    cache = stub(get=lambda url: None, add=lambda url, content: None)
+    transport = asyncio.AsyncTransport(loop=event_loop, cache=cache)
+
+    @coroutine
+    def async_getter():
+        return transport.load('http://tests.python-zeep.org/test.xml')
+
+    with requests_mock.mock() as m:
+        m.get('http://tests.python-zeep.org/test.xml', text='x')
+        result = yield from async_getter()
+
         assert result == b'x'
 
 


### PR DESCRIPTION
Use temporary requests.Session with data copied from aiohttp.session

Closes-bug: #381