### PR TITLE
Fix reference to etree.XMLSyntaxError msg property

### DIFF
--- a/src/zeep/loader.py
+++ b/src/zeep/loader.py
@@ -43,7 +43,7 @@ def parse_xml(content, transport, base_url=None, strict=False):
     try:
         return fromstring(content, parser=parser, base_url=base_url)
     except etree.XMLSyntaxError as exc:
-        raise XMLSyntaxError("Invalid XML content received (%s)" % exc.message)
+        raise XMLSyntaxError("Invalid XML content received (%s)" % exc.msg)
 
 
 def load_external(url, transport, base_url=None, strict=True):


### PR DESCRIPTION
With zeep-1.3.0 and lxml-3.7.3 I encountered an etree.XMLSyntaxError and I was getting this Traceback:
```
  File "C:\Users\sinicaan\sources\python-zeep\src\zeep\client.py", line 41, in __call__
    self._op_name, args, kwargs)
  File "C:\Users\sinicaan\sources\python-zeep\src\zeep\wsdl\bindings\soap.py", line 115, in send
    return self.process_reply(client, operation_obj, response)
  File "C:\Users\sinicaan\sources\python-zeep\src\zeep\wsdl\bindings\soap.py", line 148, in process_reply
    doc = parse_xml(content, self.transport)
  File "C:\Users\sinicaan\sources\python-zeep\src\zeep\loader.py", line 46, in parse_xml
    raise XMLSyntaxError("Invalid XML content received (%s)" % exc.message)
AttributeError: 'XMLSyntaxError' object has no attribute 'message'
```

After debugging this line I found that `exc` doesn't have `message` attribute, but just `msg`.
I will submit the error encountered in a different issue as I still didn't come to an obvious solution.