### PR TITLE
Fix: aioresponses in setup requirements while used for tests only #415

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ docs_require = [
 
 async_require = [
     'aiohttp>=1.0',
-    'aioresponses>=0.1.3',
 ]
 
 xmlsec_require = [


### PR DESCRIPTION
Drop aioresponses from setup requirements