### PR TITLE
Don't expect unicode response data

### DIFF
--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -156,7 +156,7 @@ class SoapBinding(Binding):
                 xml_huge_tree=client.xml_huge_tree)
         except XMLSyntaxError:
             raise TransportError(
-                u'Server returned HTTP status %d (%s)'
+                'Server returned HTTP status %d (%s)'
                 % (response.status_code, response.content))
 
         if client.wsse:


### PR DESCRIPTION
Create 2 tests that assert a TransportError is raised if the content can be parsed as xml, regardless of the character encoding.

Don't try to encode the webservice response content as unicode, as this may fail.