### PR TITLE
Signature/dump works with recursive data structures

### DIFF
--- a/src/zeep/utils.py
+++ b/src/zeep/utils.py
@@ -85,3 +85,9 @@ def get_media_type(value):
     """Parse a HTTP content-type header and return the media-type"""
     main_value, parameters = cgi.parse_header(value)
     return main_value
+
+def extend_path(path, item):
+    if path is None:
+        return [item]
+    else:
+        return path + [item]

--- a/src/zeep/xsd/elements/any.py
+++ b/src/zeep/xsd/elements/any.py
@@ -201,7 +201,7 @@ class Any(Base):
     def resolve(self):
         return self
 
-    def signature(self, schema=None, standalone=True):
+    def signature(self, schema=None, standalone=True, path=None):
         if self.restrict:
             base = self.restrict.name
         else:
@@ -239,5 +239,5 @@ class AnyAttribute(Base):
         for name, val in value.items():
             parent.set(name, val)
 
-    def signature(self, schema=None, standalone=True):
+    def signature(self, schema=None, standalone=True, path=None):
         return '{}'

--- a/src/zeep/xsd/elements/attribute.py
+++ b/src/zeep/xsd/elements/attribute.py
@@ -1,8 +1,10 @@
 import logging
 
+
 from lxml import etree
 
 from zeep import exceptions
+from zeep import utils
 from zeep.xsd.const import NotSet
 from zeep.xsd.elements.element import Element
 
@@ -88,5 +90,6 @@ class AttributeGroup(object):
         self._attributes = resolved
         return self
 
-    def signature(self, schema=None, standalone=True):
-        return ', '.join(attr.signature(schema) for attr in self._attributes)
+    def signature(self, schema=None, standalone=True, path=None):
+        path = utils.extend_path(path, self)
+        return ', '.join(attr.signature(schema, path=path) for attr in self._attributes)

--- a/src/zeep/xsd/elements/base.py
+++ b/src/zeep/xsd/elements/base.py
@@ -40,5 +40,6 @@ class Base(object):
         """
         raise NotImplementedError()
 
-    def signature(self, schema=None, standalone=False):
+    def signature(self, schema=None, standalone=False, path=None):
         return ''
+

--- a/src/zeep/xsd/elements/element.py
+++ b/src/zeep/xsd/elements/element.py
@@ -4,6 +4,7 @@ import logging
 from lxml import etree
 
 from zeep import exceptions
+from zeep import utils
 from zeep.exceptions import UnexpectedElementError
 from zeep.utils import qname_attr
 from zeep.xsd.const import Nil, NotSet, xsi_ns
@@ -255,12 +256,13 @@ class Element(Base):
         self.resolve_type()
         return self
 
-    def signature(self, schema=None, standalone=True):
+    def signature(self, schema=None, standalone=True, path=None):
         from zeep.xsd import ComplexType
         if self.type.is_global:
             value = self.type.get_prefixed_name(schema)
         else:
-            value = self.type.signature(schema, standalone=False)
+            path = utils.extend_path(path, self)
+            value = self.type.signature(schema, standalone=False, path=path)
 
             if not standalone and isinstance(self.type, ComplexType):
                 value = '{%s}' % value
@@ -271,3 +273,4 @@ class Element(Base):
         if self.accepts_multiple:
             return '%s[]' % value
         return value
+

--- a/src/zeep/xsd/types/base.py
+++ b/src/zeep/xsd/types/base.py
@@ -63,5 +63,5 @@ class Type(object):
         return []
 
     @classmethod
-    def signature(cls, schema=None, standalone=True):
+    def signature(cls, schema=None, standalone=True, path=None):
         return ''

--- a/src/zeep/xsd/types/collection.py
+++ b/src/zeep/xsd/types/collection.py
@@ -1,4 +1,4 @@
-from zeep.utils import get_base_class
+from zeep.utils import get_base_class, extend_path
 from zeep.xsd.types.simple import AnySimpleType
 
 __all__ = ['ListType', 'UnionType']
@@ -32,8 +32,9 @@ class ListType(AnySimpleType):
         item_type = self.item_type
         return [item_type.pythonvalue(v) for v in value.split()]
 
-    def signature(self, schema=None, standalone=True):
-        return self.item_type.signature(schema) + '[]'
+    def signature(self, schema=None, standalone=True, path=None):
+        path = extend_path(path, self)
+        return self.item_type.signature(schema, path=path) + '[]'
 
 
 class UnionType(AnySimpleType):
@@ -52,7 +53,7 @@ class UnionType(AnySimpleType):
             self.item_class = base_class
         return self
 
-    def signature(self, schema=None, standalone=True):
+    def signature(self, schema=None, standalone=True, path=None):
         return ''
 
     def parse_xmlelement(self, xmlelement, schema=None, allow_none=True,

--- a/src/zeep/xsd/types/complex.py
+++ b/src/zeep/xsd/types/complex.py
@@ -5,6 +5,7 @@ from itertools import chain
 
 from cached_property import threaded_cached_property
 
+from zeep import utils
 from zeep.exceptions import UnexpectedElementError, XMLParseError
 from zeep.xsd.const import NotSet, SkipValue, xsi_ns
 from zeep.xsd.elements import (
@@ -431,14 +432,20 @@ class ComplexType(AnyType):
             is_global=self.is_global)
         return new.resolve()
 
-    def signature(self, schema=None, standalone=True):
+    def signature(self, schema=None, standalone=True, path=None):
         parts = []
+
+        path = utils.extend_path(path, self)
+
         for name, element in self.elements_nested:
-            part = element.signature(schema, standalone=False)
+            if element in path:
+                part = '%s(...)' % name
+            else:
+                part = element.signature(schema, standalone=False, path=path)
             parts.append(part)
 
         for name, attribute in self.attributes:
-            part = '%s: %s' % (name, attribute.signature(schema, standalone=False))
+            part = '%s: %s' % (name, attribute.signature(schema, standalone=False, path=path))
             parts.append(part)
 
         value = ', '.join(parts)

--- a/src/zeep/xsd/types/simple.py
+++ b/src/zeep/xsd/types/simple.py
@@ -70,7 +70,7 @@ class AnySimpleType(AnyType):
     def render(self, parent, value, xsd_type=None, render_path=None):
         parent.text = self.xmlvalue(value)
 
-    def signature(self, schema=None, standalone=True):
+    def signature(self, schema=None, standalone=True, path=None):
         return self.get_prefixed_name(schema)
 
     def validate(self, value, required=False):

--- a/tests/test_recursive_error.py
+++ b/tests/test_recursive_error.py
@@ -1,0 +1,3 @@
+from zeep import Client
+client=Client("file://test_recursive_error.wsdl")
+client.wsdl.dump()

--- a/tests/test_recursive_error.py
+++ b/tests/test_recursive_error.py
@@ -1,3 +1,0 @@
-from zeep import Client
-client=Client("file://test_recursive_error.wsdl")
-client.wsdl.dump()


### PR DESCRIPTION
This should solve issues #454 and #451. The main change is that signature() methods are keeping track the path of the object, and it will not dump nested elements if they are already in the path.