### PR TITLE
added ability to specify multiple WSSE items

### DIFF
--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -86,7 +86,11 @@ class SoapBinding(Binding):
 
             # Apply WSSE
             if client.wsse:
-                envelope, http_headers = client.wsse.apply(envelope, http_headers)
+                if type(client.wsse) == list:
+                    for obj in client.wsse:
+                        envelope, http_headers = obj.apply(envelope, http_headers)
+                else:
+                    envelope, http_headers = client.wsse.apply(envelope, http_headers)
         return envelope, http_headers
 
     def send(self, client, options, operation, args, kwargs):


### PR DESCRIPTION
The old functionality remains, but can also do this:

```
client = Client(
     'http://www.webservicex.net/ConvertSpeed.asmx?WSDL',
     wsse=[UsernameToken('username', 'password')),
           Signature(private_key_filename, public_key_filename,optional_password))]
 )
```