### PR TITLE
Prevent some cases where annotations cause unnecessary errors.

### DIFF
--- a/src/zeep/xsd/visitor.py
+++ b/src/zeep/xsd/visitor.py
@@ -886,6 +886,9 @@ class SchemaVisitor(object):
 
         for child in node.iterchildren():
             assert child.tag in sub_types, child
+            # TODO: We should actually process the Annotation, rather than skipping it.
+            if child.tag == tags.annotation:
+                continue
             item = self.process(child, node)
             result.append(item)
 


### PR DESCRIPTION
This prevents some unnecessary errors zeep was producing when handling annotations in a SOAP API I was working with.