### PR TITLE
Fix: XMLSyntaxError does not store error details inside #514

### DIFF
--- a/src/zeep/exceptions.py
+++ b/src/zeep/exceptions.py
@@ -8,7 +8,9 @@ class Error(Exception):
 
 
 class XMLSyntaxError(Error):
-    pass
+    def __init__(self, *args, **kwargs):
+        self.content = kwargs.pop('content', None)
+        super(XMLSyntaxError, self).__init__(*args, **kwargs)
 
 
 class XMLParseError(Error):

--- a/src/zeep/loader.py
+++ b/src/zeep/loader.py
@@ -46,7 +46,10 @@ def parse_xml(content, transport, base_url=None, strict=True,
     try:
         return fromstring(content, parser=parser, base_url=base_url)
     except etree.XMLSyntaxError as exc:
-        raise XMLSyntaxError("Invalid XML content received (%s)" % exc.msg)
+        raise XMLSyntaxError(
+            "Invalid XML content received (%s)" % exc.msg,
+            content=content
+        )
 
 
 def load_external(url, transport, base_url=None, strict=True):


### PR DESCRIPTION
  In some cases (load phase)
  XMLSyntaxError is raised instead of TransportError
  (Example URL:
   https://webservices2.autotask.net/ATServices/1.5/atws.asmx?WSDL
  )
Add content optional field.