### PR TITLE
Add Support For Tornado Async Transport

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,7 @@ Highlights:
  * Support for Soap 1.1, Soap 1.2 and HTTP bindings
  * Support for WS-Addressing headers
  * Support for WSSE (UserNameToken / x.509 signing)
+ * Support for tornado async transport via gen.coroutine (Python 2.7+)
  * Support for asyncio via aiohttp (Python 3.5+)
  * Experimental support for XOP messages
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Highlights:
  * Support for Soap 1.1, Soap 1.2 and HTTP bindings
  * Support for WS-Addressing headers
  * Support for WSSE (UserNameToken / x.509 signing)
+ * Support for tornado async transport via gen.coroutine (Python 2.7+)
  * Support for asyncio via aiohttp (Python 3.5+)
  * Experimental support for XOP messages
 
@@ -83,10 +84,16 @@ xmlsec module. This can be done by install the ``xlmsec`` extras::
 
     pip install zeep[xmlsec]
 
-For the asyncio support in Python 3.5+ the aiohttp module is required, this 
+For the asyncio support in Python 3.5+ the aiohttp module is required, this
 can be installed with the ``async`` extras::
 
     pip install zeep[async]
+
+
+For the tornado support in Python 2.7+ the tornado module is required, this
+can be installed with the ``tornado`` extras::
+
+    pip install zeep[tornado]
 
 
 Getting started

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ docs_require = [
     'sphinx>=1.4.0',
 ]
 
+tornado_require = [
+    'tornado==4.0.2'
+]
+
 async_require = []  # see below
 
 xmlsec_require = [
@@ -32,6 +36,7 @@ tests_require = [
     'pytest-cov==2.5.1',
     'pytest==3.1.3',
     'requests_mock>=0.7.0',
+    'pytest-tornado==0.4.5',
 
     # Linting
     'isort==4.2.5',
@@ -66,6 +71,7 @@ setup(
         'docs': docs_require,
         'test': tests_require,
         'async': async_require,
+        'tornado': tornado_require,
         'xmlsec': xmlsec_require,
     },
     entry_points={},

--- a/src/zeep/asyncio/transport.py
+++ b/src/zeep/asyncio/transport.py
@@ -4,6 +4,7 @@ Adds asyncio support to Zeep. Contains Python 3.5+ only syntax!
 """
 import asyncio
 import logging
+import bindings
 
 import aiohttp
 from requests import Response
@@ -17,7 +18,10 @@ __all__ = ['AsyncTransport']
 
 class AsyncTransport(Transport):
     """Asynchronous Transport class using aiohttp."""
-    supports_async = True
+    binding_classes = [
+                bindings.AsyncSoap11Binding,
+                bindings.AsyncSoap12Binding,
+            ]
 
     def __init__(self, loop, cache=None, timeout=300, operation_timeout=None,
                  session=None):

--- a/src/zeep/asyncio/transport.py
+++ b/src/zeep/asyncio/transport.py
@@ -4,7 +4,7 @@ Adds asyncio support to Zeep. Contains Python 3.5+ only syntax!
 """
 import asyncio
 import logging
-import bindings
+from . import bindings
 
 import aiohttp
 from requests import Response

--- a/src/zeep/tornado/__init__.py
+++ b/src/zeep/tornado/__init__.py
@@ -1,0 +1,2 @@
+from .transport import *  # noqa
+from .bindings import *  # noqa

--- a/src/zeep/tornado/bindings.py
+++ b/src/zeep/tornado/bindings.py
@@ -1,0 +1,28 @@
+from zeep.wsdl import bindings
+from tornado import gen
+
+__all__ = ['AsyncSoap11Binding', 'AsyncSoap12Binding']
+
+
+class AsyncSoapBinding(object):
+
+    @gen.coroutine
+    def send(self, client, options, operation, args, kwargs):
+        envelope, http_headers = self._create(
+            operation, args, kwargs,
+            client=client,
+            options=options)
+
+        response = client.transport.post_xml(
+            options['address'], envelope, http_headers)
+
+        operation_obj = self.get(operation)
+        return self.process_reply(client, operation_obj, response)
+
+
+class AsyncSoap11Binding(AsyncSoapBinding, bindings.Soap11Binding):
+    pass
+
+
+class AsyncSoap12Binding(AsyncSoapBinding, bindings.Soap12Binding):
+    pass

--- a/src/zeep/tornado/bindings.py
+++ b/src/zeep/tornado/bindings.py
@@ -13,11 +13,11 @@ class AsyncSoapBinding(object):
             client=client,
             options=options)
 
-        response = client.transport.post_xml(
+        response = yield client.transport.post_xml(
             options['address'], envelope, http_headers)
 
         operation_obj = self.get(operation)
-        return self.process_reply(client, operation_obj, response)
+        raise gen.Return(self.process_reply(client, operation_obj, response))
 
 
 class AsyncSoap11Binding(AsyncSoapBinding, bindings.Soap11Binding):

--- a/src/zeep/tornado/transport.py
+++ b/src/zeep/tornado/transport.py
@@ -33,20 +33,16 @@ class TornadoAsyncTransport(Transport):
         self.session.headers['User-Agent'] = (
             'Zeep/%s (www.python-zeep.org)' % (get_version()))
 
-    @gen.coroutine
     def _load_remote_data(self, url):
-        result = None
+        @gen.coroutine
+        def _load_remote_data_async():
+            async_client = httpclient.AsyncHTTPClient()
+            kwargs = {'method': 'GET'}
+            http_req = httpclient.HTTPRequest(url, **kwargs)
+            response = yield async_client.fetch(http_req)
+            raise gen.Return(self.new_response(response))
 
-        async_client = httpclient.AsyncHTTPClient()
-
-        kwargs = {
-            'method': 'GET'
-        }
-
-        http_req = httpclient.HTTPRequest(url, **kwargs)
-        response = yield async_client.fetch(http_req)
-
-        raise gen.Return(self.new_response(response))
+        return self.loop.run_sync(_load_remote_data_async())
 
     @gen.coroutine
     def post(self, address, message, headers):

--- a/src/zeep/tornado/transport.py
+++ b/src/zeep/tornado/transport.py
@@ -5,7 +5,7 @@ Adds async tornado.gen support to Zeep.
 import logging
 import urllib
 import tornado.ioloop
-from tornado import gen, httpclient, IOLoop
+from tornado import gen, httpclient
 from requests import Response, Session
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 

--- a/src/zeep/tornado/transport.py
+++ b/src/zeep/tornado/transport.py
@@ -4,7 +4,7 @@ Adds async tornado.gen support to Zeep.
 """
 import logging
 import urllib
-import bindings
+from . import bindings
 
 from tornado import gen, httpclient
 from requests import Response, Session

--- a/src/zeep/tornado/transport.py
+++ b/src/zeep/tornado/transport.py
@@ -99,12 +99,10 @@ class TornadoAsyncTransport(Transport):
                 client_cert = self.session.cert[0]
                 client_key = self.session.cert[1]
 
-        parsed_headears = {v[0]: v[1] for k, v in self.session.headers._store.iteritems()}
-
         kwargs = {
             'method': method,
             'request_timeout': self.load_timeout,
-            'headers': dict(headers, **parsed_headears),
+            'headers': dict(headers, **self.session.headers.items()),
             'auth_username': auth_username,
             'auth_password': auth_password,
             'auth_mode': auth_mode,

--- a/src/zeep/tornado/transport.py
+++ b/src/zeep/tornado/transport.py
@@ -36,7 +36,10 @@ class TornadoAsyncTransport(Transport):
 
     def _load_remote_data(self, url):
         client = httpclient.HTTPClient()
-        kwargs = {'method': 'GET'}
+        kwargs = {
+            'method': 'GET',
+            'request_timeout': self.load_timeout
+        }
         http_req = httpclient.HTTPRequest(url, **kwargs)
         response = client.fetch(http_req)
         return response.body
@@ -99,10 +102,12 @@ class TornadoAsyncTransport(Transport):
                 client_cert = self.session.cert[0]
                 client_key = self.session.cert[1]
 
+        session_headers = dict(self.session.headers.items())
+
         kwargs = {
             'method': method,
-            'request_timeout': self.load_timeout,
-            'headers': dict(headers, **self.session.headers.items()),
+            'request_timeout': self.operation_timeout,
+            'headers': dict(headers, **session_headers),
             'auth_username': auth_username,
             'auth_password': auth_password,
             'auth_mode': auth_mode,
@@ -124,5 +129,5 @@ class TornadoAsyncTransport(Transport):
         new = Response()
         new._content = response.body
         new.status_code = response.code
-        new.headers = response.headers # seems that headers may be in a wrong format here
+        new.headers = dict(response.headers.get_all())
         return new

--- a/src/zeep/tornado/transport.py
+++ b/src/zeep/tornado/transport.py
@@ -5,7 +5,7 @@ Adds async tornado.gen support to Zeep.
 import logging
 import urllib
 import tornado.ioloop
-from tornado import gen, httpclient
+from tornado import gen, httpclient, IOLoop
 from requests import Response, Session
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 
@@ -20,10 +20,8 @@ class TornadoAsyncTransport(Transport):
     """Asynchronous Transport class using tornado gen."""
     supports_async = True
 
-    def __init__(self, loop, cache=None, timeout=300, operation_timeout=None,
+    def __init__(self, cache=None, timeout=300, operation_timeout=None,
                  session=None):
-
-        self.loop = loop if loop else tornado.ioloop.IOLoop.instance()
         self.cache = cache
         self.load_timeout = timeout
         self.operation_timeout = operation_timeout
@@ -34,6 +32,7 @@ class TornadoAsyncTransport(Transport):
             'Zeep/%s (www.python-zeep.org)' % (get_version()))
 
     def _load_remote_data(self, url):
+
         @gen.coroutine
         def _load_remote_data_async():
             async_client = httpclient.AsyncHTTPClient()
@@ -42,7 +41,7 @@ class TornadoAsyncTransport(Transport):
             response = yield async_client.fetch(http_req)
             raise gen.Return(self.new_response(response))
 
-        return self.loop.run_sync(_load_remote_data_async())
+        return tornado.ioloop.IOLoop.run_sync(_load_remote_data_async)
 
     @gen.coroutine
     def post(self, address, message, headers):

--- a/src/zeep/tornado/transport.py
+++ b/src/zeep/tornado/transport.py
@@ -36,7 +36,7 @@ class TornadoAsyncTransport(Transport):
         kwargs = {'method': 'GET'}
         http_req = httpclient.HTTPRequest(url, **kwargs)
         response = client.fetch(http_req)
-        return response
+        return response.body
 
 
         # @gen.coroutine

--- a/src/zeep/tornado/transport.py
+++ b/src/zeep/tornado/transport.py
@@ -89,7 +89,7 @@ class TornadoAsyncTransport(Transport):
         kwargs = {
             'method': 'POST',
             'request_timeout': self.load_timeout,
-            'headers': headers + CaseInsensitiveDict(self.session.headers),
+            'headers': CaseInsensitiveDict(headers) + self.session.headers,
             'auth_username': auth_username,
             'auth_password': auth_password,
             'auth_mode': auth_mode,
@@ -153,7 +153,7 @@ class TornadoAsyncTransport(Transport):
         kwargs = {
             'method': 'POST',
             'request_timeout': self.load_timeout,
-            'headers': headers + CaseInsensitiveDict(self.session.headers),
+            'headers': CaseInsensitiveDict(headers) + self.session.headers,
             'auth_username': auth_username,
             'auth_password': auth_password,
             'auth_mode': auth_mode,

--- a/src/zeep/tornado/transport.py
+++ b/src/zeep/tornado/transport.py
@@ -1,0 +1,178 @@
+"""
+Adds async tornado.gen support to Zeep.
+
+"""
+import logging
+import urllib
+import tornado.ioloop
+from tornado import gen, httpclient
+from requests import Response, Session
+from requests.auth import HTTPBasicAuth, HTTPDigestAuth
+
+from zeep.transports import Transport
+from zeep.utils import get_version
+from zeep.wsdl.utils import etree_to_string
+
+__all__ = ['AsyncTransport']
+
+
+class AsyncTransport(Transport):
+    """Asynchronous Transport class using tornado gen."""
+    supports_async = True
+
+    def __init__(self, loop, cache=None, timeout=300, operation_timeout=None,
+                 session=None):
+
+        self.loop = loop if loop else tornado.ioloop.IOLoop.instance()
+        self.cache = cache
+        self.load_timeout = timeout
+        self.operation_timeout = operation_timeout
+        self.logger = logging.getLogger(__name__)
+
+        self.session = session or Session()
+        self.session.headers['User-Agent'] = (
+            'Zeep/%s (www.python-zeep.org)' % (get_version()))
+
+    @gen.coroutine
+    def _load_remote_data(self, url):
+        result = None
+
+        async_client = httpclient.AsyncHTTPClient()
+
+        kwargs = {
+            'method': 'GET'
+        }
+
+        http_req = httpclient.HTTPRequest(url, **kwargs)
+        response = yield async_client.fetch(http_req)
+
+        raise gen.Return(self.new_response(response))
+
+    @gen.coroutine
+    def post(self, address, message, headers):
+        async_client = httpclient.AsyncHTTPClient()
+
+        # extracting auth
+        auth_username = None
+        auth_password = None
+        auth_mode = None
+
+        if self.session.auth is not None:
+            if type(self.session.auth) is tuple:
+                auth_username = self.session.auth[0]
+                auth_password = self.session.auth[1]
+                auth_mode = 'basic'
+            elif type(self.session.auth) is HTTPBasicAuth:
+                auth_username = self.session.username
+                auth_password = self.session.password
+                auth_mode = 'basic'
+            elif type(self.session.auth) is HTTPDigestAuth:
+                auth_username = self.session.username
+                auth_password = self.session.password
+                auth_mode = 'digest'
+            else:
+                raise StandardError('Not supported authentication.')
+
+        # extracting client cert
+        client_cert = None
+        client_key = None
+
+        if self.session.cert is not None:
+            if type(self.session.cert) is str:
+                client_cert = self.session.cert
+            elif type(self.session.cert) is tuple:
+                client_cert = self.session.cert[0]
+                client_key = self.session.cert[1]
+
+        kwargs = {
+            'method': 'POST',
+            'request_timeout': self.timeout,
+            'headers': headers + self.session.headers,
+            'auth_username': auth_username,
+            'auth_password': auth_password,
+            'auth_mode': auth_mode,
+            'validate_cert': self.sessionverify,
+            'client_key': client_key,
+            'client_cert': client_cert,
+            'body': message
+        }
+
+        http_req = httpclient.HTTPRequest(address, **kwargs)
+        response = yield async_client.po(http_req)
+
+        raise gen.Return(self.new_response(response))
+
+    @gen.coroutine
+    def post_xml(self, address, envelope, headers):
+        message = etree_to_string(envelope)
+
+        response = yield self.post(address, message, headers)
+
+        raise gen.Return(self.new_response(response))
+
+    @gen.coroutine
+    def get(self, address, params, headers):
+        async_client = httpclient.AsyncHTTPClient()
+        if params:
+            address += '?' + urllib.urlencode(params)
+
+        # extracting auth
+        auth_username = None
+        auth_password = None
+        auth_mode = None
+
+        if self.session.auth is not None:
+            if type(self.session.auth) is tuple:
+                auth_username = self.session.auth[0]
+                auth_password = self.session.auth[1]
+                auth_mode = 'basic'
+            elif type(self.session.auth) is HTTPBasicAuth:
+                auth_username = self.session.username
+                auth_password = self.session.password
+                auth_mode = 'basic'
+            elif type(self.session.auth) is HTTPDigestAuth:
+                auth_username = self.session.username
+                auth_password = self.session.password
+                auth_mode = 'digest'
+            else:
+                raise StandardError('Not supported authentication.')
+
+        # extracting client cert
+        client_cert = None
+        client_key = None
+
+        if self.session.cert is not None:
+            if type(self.session.cert) is str:
+                client_cert = self.session.cert
+            elif type(self.session.cert) is tuple:
+                client_cert = self.session.cert[0]
+                client_key = self.session.cert[1]
+
+        kwargs = {
+            'method': 'GET',
+            'request_timeout': self.timeout,
+            'headers': headers + self.session.headers,
+            'auth_username': auth_username,
+            'auth_password': auth_password,
+            'auth_mode': auth_mode,
+            'validate_cert': self.sessionverify,
+            'client_key': client_key,
+            'client_cert': client_cert
+
+
+        }
+
+        http_req = httpclient.HTTPRequest(address, **kwargs)
+        response = yield async_client.fetch(http_req)
+
+        raise gen.Return(self.new_response(response))
+
+    def new_response(self, response):
+        """Convert an tornado.HTTPResponse object to a requests.Response object"""
+        new = Response()
+        new._content = response.body
+        new.status_code = response.code
+        new.headers = response.headers # seems that headers may be in a wrong format here
+        # new.cookies = response.cookies
+        # new.encoding = response.charset
+        return new

--- a/src/zeep/tornado/transport.py
+++ b/src/zeep/tornado/transport.py
@@ -13,10 +13,10 @@ from zeep.transports import Transport
 from zeep.utils import get_version
 from zeep.wsdl.utils import etree_to_string
 
-__all__ = ['AsyncTransport']
+__all__ = ['TornadoAsyncTransport']
 
 
-class AsyncTransport(Transport):
+class TornadoAsyncTransport(Transport):
     """Asynchronous Transport class using tornado gen."""
     supports_async = True
 

--- a/src/zeep/tornado/transport.py
+++ b/src/zeep/tornado/transport.py
@@ -87,12 +87,12 @@ class TornadoAsyncTransport(Transport):
 
         kwargs = {
             'method': 'POST',
-            'request_timeout': self.timeout,
+            'request_timeout': self.load_timeout,
             'headers': headers + self.session.headers,
             'auth_username': auth_username,
             'auth_password': auth_password,
             'auth_mode': auth_mode,
-            'validate_cert': self.sessionverify,
+            'validate_cert': self.session.sessionverify if self.session else None,
             'client_key': client_key,
             'client_cert': client_cert,
             'body': message
@@ -150,17 +150,15 @@ class TornadoAsyncTransport(Transport):
                 client_key = self.session.cert[1]
 
         kwargs = {
-            'method': 'GET',
-            'request_timeout': self.timeout,
+            'method': 'POST',
+            'request_timeout': self.load_timeout,
             'headers': headers + self.session.headers,
             'auth_username': auth_username,
             'auth_password': auth_password,
             'auth_mode': auth_mode,
-            'validate_cert': self.sessionverify,
+            'validate_cert': self.session.sessionverify if self.session else None,
             'client_key': client_key,
             'client_cert': client_cert
-
-
         }
 
         http_req = httpclient.HTTPRequest(address, **kwargs)

--- a/src/zeep/tornado/transport.py
+++ b/src/zeep/tornado/transport.py
@@ -4,6 +4,8 @@ Adds async tornado.gen support to Zeep.
 """
 import logging
 import urllib
+import bindings
+
 from tornado import gen, httpclient
 from requests import Response, Session
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
@@ -17,7 +19,9 @@ __all__ = ['TornadoAsyncTransport']
 
 class TornadoAsyncTransport(Transport):
     """Asynchronous Transport class using tornado gen."""
-    supports_async = True
+    binding_classes = [
+        bindings.AsyncSoap11Binding,
+        bindings.AsyncSoap12Binding]
 
     def __init__(self, cache=None, timeout=300, operation_timeout=None,
                  session=None):

--- a/src/zeep/tornado/transport.py
+++ b/src/zeep/tornado/transport.py
@@ -32,16 +32,22 @@ class TornadoAsyncTransport(Transport):
             'Zeep/%s (www.python-zeep.org)' % (get_version()))
 
     def _load_remote_data(self, url):
+        client = httpclient.HTTPClient()
+        kwargs = {'method': 'GET'}
+        http_req = httpclient.HTTPRequest(url, **kwargs)
+        response = client.fetch(http_req)
+        return response
 
-        @gen.coroutine
-        def _load_remote_data_async():
-            async_client = httpclient.AsyncHTTPClient()
-            kwargs = {'method': 'GET'}
-            http_req = httpclient.HTTPRequest(url, **kwargs)
-            response = yield async_client.fetch(http_req)
-            raise gen.Return(self.new_response(response))
 
-        return tornado.ioloop.IOLoop.run_sync(_load_remote_data_async)
+        # @gen.coroutine
+        # def _load_remote_data_async():
+        #     async_client = httpclient.AsyncHTTPClient()
+        #     kwargs = {'method': 'GET'}
+        #     http_req = httpclient.HTTPRequest(url, **kwargs)
+        #     response = yield async_client.fetch(http_req)
+        #     raise gen.Return(self.new_response(response))
+        #
+        # return tornado.ioloop.IOLoop.run_sync(_load_remote_data_async)
 
     @gen.coroutine
     def post(self, address, message, headers):

--- a/src/zeep/tornado/transport.py
+++ b/src/zeep/tornado/transport.py
@@ -7,6 +7,7 @@ import urllib
 import tornado.ioloop
 from tornado import gen, httpclient
 from requests import Response, Session
+from requests.structures import CaseInsensitiveDict
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 
 from zeep.transports import Transport
@@ -88,7 +89,7 @@ class TornadoAsyncTransport(Transport):
         kwargs = {
             'method': 'POST',
             'request_timeout': self.load_timeout,
-            'headers': headers + self.session.headers,
+            'headers': headers + CaseInsensitiveDict(self.session.headers),
             'auth_username': auth_username,
             'auth_password': auth_password,
             'auth_mode': auth_mode,
@@ -152,7 +153,7 @@ class TornadoAsyncTransport(Transport):
         kwargs = {
             'method': 'POST',
             'request_timeout': self.load_timeout,
-            'headers': headers + self.session.headers,
+            'headers': headers + CaseInsensitiveDict(self.session.headers),
             'auth_username': auth_username,
             'auth_password': auth_password,
             'auth_mode': auth_mode,

--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -7,6 +7,7 @@ from six.moves.urllib.parse import urlparse
 
 from zeep.utils import get_media_type, get_version
 from zeep.wsdl.utils import etree_to_string
+from zeep.wsdl import bindings
 
 
 class Transport(object):
@@ -19,7 +20,12 @@ class Transport(object):
     :param session: A :py:class:`request.Session()` object (optional)
 
     """
-    supports_async = False
+    binding_classes = [
+                bindings.Soap11Binding,
+                bindings.Soap12Binding,
+                bindings.HttpGetBinding,
+                bindings.HttpPostBinding,
+            ]
 
     def __init__(self, cache=None, timeout=300, operation_timeout=None,
                  session=None):

--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -7,7 +7,6 @@ from six.moves.urllib.parse import urlparse
 
 from zeep.utils import get_media_type, get_version
 from zeep.wsdl.utils import etree_to_string
-from zeep.wsdl import bindings
 
 
 class Transport(object):
@@ -20,12 +19,6 @@ class Transport(object):
     :param session: A :py:class:`request.Session()` object (optional)
 
     """
-    binding_classes = [
-                bindings.Soap11Binding,
-                bindings.Soap12Binding,
-                bindings.HttpGetBinding,
-                bindings.HttpPostBinding,
-            ]
 
     def __init__(self, cache=None, timeout=300, operation_timeout=None,
                  session=None):

--- a/src/zeep/wsdl/wsdl.py
+++ b/src/zeep/wsdl/wsdl.py
@@ -390,10 +390,21 @@ class Definition(object):
         """
         result = {}
 
+        if not getattr(self.wsdl.transport, 'binding_classes', None):
+            from zeep.wsdl import bindings
+            binding_classes = [
+                bindings.Soap11Binding,
+                bindings.Soap12Binding,
+                bindings.HttpGetBinding,
+                bindings.HttpPostBinding,
+            ]
+        else:
+            binding_classes = self.wsdl.transport.binding_classes
+
         for binding_node in doc.findall('wsdl:binding', namespaces=NSMAP):
             # Detect the binding type
             binding = None
-            for binding_class in self.wsdl.transport.binding_classes:
+            for binding_class in binding_classes:
                 if binding_class.match(binding_node):
 
                     try:

--- a/src/zeep/wsdl/wsdl.py
+++ b/src/zeep/wsdl/wsdl.py
@@ -398,7 +398,7 @@ class Definition(object):
                 bindings.HttpPostBinding,
             ]
         else:
-            from zeep.asyncio import bindings  # Python 3.5+ syntax
+            from zeep.tornado import bindings  # TODO: Fix-me !!!!
             binding_classes = [
                 bindings.AsyncSoap11Binding,
                 bindings.AsyncSoap12Binding,

--- a/src/zeep/wsdl/wsdl.py
+++ b/src/zeep/wsdl/wsdl.py
@@ -389,25 +389,11 @@ class Definition(object):
 
         """
         result = {}
-        if not getattr(self.wsdl.transport, 'supports_async', False):
-            from zeep.wsdl import bindings
-            binding_classes = [
-                bindings.Soap11Binding,
-                bindings.Soap12Binding,
-                bindings.HttpGetBinding,
-                bindings.HttpPostBinding,
-            ]
-        else:
-            from zeep.tornado import bindings  # TODO: Fix-me !!!!
-            binding_classes = [
-                bindings.AsyncSoap11Binding,
-                bindings.AsyncSoap12Binding,
-            ]
 
         for binding_node in doc.findall('wsdl:binding', namespaces=NSMAP):
             # Detect the binding type
             binding = None
-            for binding_class in binding_classes:
+            for binding_class in self.wsdl.transport.binding_classes:
                 if binding_class.match(binding_node):
 
                     try:

--- a/tests/test_tornado_transport.py
+++ b/tests/test_tornado_transport.py
@@ -1,0 +1,56 @@
+from pretend import stub
+from lxml import etree
+from tornado.httpclient import HTTPResponse, HTTPRequest
+from tornado.testing import gen_test, AsyncTestCase
+from tornado.concurrent import Future
+
+from mock import patch
+from zeep import tornado
+
+
+class TornadoAsyncTransportTest(AsyncTestCase):
+    def test_no_cache(self):
+        transport = tornado.TornadoAsyncTransport()
+        assert transport.cache is None
+
+
+    @patch('tornado.httpclient.HTTPClient.fetch')
+    @gen_test
+    def test_load(self, mock_httpclient_fetch):
+        cache = stub(get=lambda url: None, add=lambda url, content: None)
+        response = HTTPResponse(HTTPRequest('http://tests.python-zeep.org/test.xml'), 200)
+        response.buffer = True
+        response._body = 'x'
+        mock_httpclient_fetch.return_value = response
+
+        transport = tornado.TornadoAsyncTransport(cache=cache)
+
+        result = transport.load('http://tests.python-zeep.org/test.xml')
+
+        assert result == b'x'
+
+
+    @patch('tornado.httpclient.AsyncHTTPClient.fetch')
+    @gen_test
+    def test_post(self, mock_httpclient_fetch):
+        cache = stub(get=lambda url: None, add=lambda url, content: None)
+
+        response = HTTPResponse(HTTPRequest('http://tests.python-zeep.org/test.xml'), 200)
+        response.buffer = True
+        response._body = 'x'
+        http_fetch_future = Future()
+        http_fetch_future.set_result(response)
+        mock_httpclient_fetch.return_value = http_fetch_future
+
+        transport = tornado.TornadoAsyncTransport(cache=cache)
+
+        envelope = etree.Element('Envelope')
+
+        result = yield transport.post_xml(
+            'http://tests.python-zeep.org/test.xml',
+            envelope=envelope,
+            headers={})
+
+        assert result.content == b'x'
+        assert result.status_code == 200
+

--- a/tests/test_tornado_transport.py
+++ b/tests/test_tornado_transport.py
@@ -4,8 +4,12 @@ from lxml import etree
 from tornado.httpclient import HTTPResponse, HTTPRequest
 from tornado.testing import gen_test, AsyncTestCase
 from tornado.concurrent import Future
+from requests import Session
+from requests.structures import CaseInsensitiveDict
 
-from mock import patch
+from tornado.httputil import HTTPHeaders
+
+from mock import patch, ANY
 from zeep import tornado
 
 
@@ -55,4 +59,3 @@ class TornadoAsyncTransportTest(AsyncTestCase):
 
         assert result.content == 'x'
         assert result.status_code == 200
-

--- a/tests/test_tornado_transport.py
+++ b/tests/test_tornado_transport.py
@@ -4,19 +4,15 @@ from lxml import etree
 from tornado.httpclient import HTTPResponse, HTTPRequest
 from tornado.testing import gen_test, AsyncTestCase
 from tornado.concurrent import Future
-from requests import Session
-from requests.structures import CaseInsensitiveDict
 
-from tornado.httputil import HTTPHeaders
-
-from mock import patch, ANY
-from zeep import tornado
+from mock import patch
+from zeep.tornado import TornadoAsyncTransport
 
 
 class TornadoAsyncTransportTest(AsyncTestCase):
     @pytest.mark.requests
     def test_no_cache(self):
-        transport = tornado.TornadoAsyncTransport()
+        transport = TornadoAsyncTransport()
         assert transport.cache is None
 
     @pytest.mark.requests
@@ -29,7 +25,7 @@ class TornadoAsyncTransportTest(AsyncTestCase):
         response._body = 'x'
         mock_httpclient_fetch.return_value = response
 
-        transport = tornado.TornadoAsyncTransport(cache=cache)
+        transport = TornadoAsyncTransport(cache=cache)
 
         result = transport.load('http://tests.python-zeep.org/test.xml')
 
@@ -48,7 +44,7 @@ class TornadoAsyncTransportTest(AsyncTestCase):
         http_fetch_future.set_result(response)
         mock_httpclient_fetch.return_value = http_fetch_future
 
-        transport = tornado.TornadoAsyncTransport(cache=cache)
+        transport = TornadoAsyncTransport(cache=cache)
 
         envelope = etree.Element('Envelope')
 

--- a/tests/test_tornado_transport.py
+++ b/tests/test_tornado_transport.py
@@ -1,3 +1,4 @@
+import pytest
 from pretend import stub
 from lxml import etree
 from tornado.httpclient import HTTPResponse, HTTPRequest
@@ -9,11 +10,12 @@ from zeep import tornado
 
 
 class TornadoAsyncTransportTest(AsyncTestCase):
+    @pytest.mark.requests
     def test_no_cache(self):
         transport = tornado.TornadoAsyncTransport()
         assert transport.cache is None
 
-
+    @pytest.mark.requests
     @patch('tornado.httpclient.HTTPClient.fetch')
     @gen_test
     def test_load(self, mock_httpclient_fetch):
@@ -27,9 +29,9 @@ class TornadoAsyncTransportTest(AsyncTestCase):
 
         result = transport.load('http://tests.python-zeep.org/test.xml')
 
-        assert result == b'x'
+        assert result == 'x'
 
-
+    @pytest.mark.requests
     @patch('tornado.httpclient.AsyncHTTPClient.fetch')
     @gen_test
     def test_post(self, mock_httpclient_fetch):
@@ -51,6 +53,6 @@ class TornadoAsyncTransportTest(AsyncTestCase):
             envelope=envelope,
             headers={})
 
-        assert result.content == b'x'
+        assert result.content == 'x'
         assert result.status_code == 200
 


### PR DESCRIPTION
Pull request includes:
- support for tornado `gen.coroutine` async transport (non blocking I/O for Python 2.7+)
- light change in `wsdl.py` to allow transport customizations, it should be enough to inherit new transport class from `zeep.Transport` and link it with your bindings if necessary (didn't document that)
- unit tests for `TornadoAsyncTransport`
- setup and documentation updates