### PR TITLE
Support completion of operation names for ServiceProxy

### DIFF
--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -13,7 +13,11 @@ class OperationProxy(object):
     def __init__(self, service_proxy, operation_name):
         self._proxy = service_proxy
         self._op_name = operation_name
-        self.__doc__ = 'OperationProxy for %s' % operation_name
+        try:
+            signature = str(self._proxy._binding._operations[operation_name])
+            self.__doc__ = signature
+        except:
+            self.__doc__ = 'OperationProxy for %s' % operation_name
 
     def __call__(self, *args, **kwargs):
         """Call the operation with the given args and kwargs.

--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -70,7 +70,7 @@ class ServiceProxy(object):
         
     def __dir__(self):
         """ Return the names of the operations. """
-        return list(super(ServiceProxy, self).__dir__()
+        return list(dir(super(ServiceProxy, self))
                     + list(self.__dict__)
                     + list(self._binding.port_type.operations))
                     # using list() on the dicts for Python 3 compatibility

--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -13,6 +13,7 @@ class OperationProxy(object):
     def __init__(self, service_proxy, operation_name):
         self._proxy = service_proxy
         self._op_name = operation_name
+        self.__doc__ = 'OperationProxy for %s' % operation_name
 
     def __call__(self, *args, **kwargs):
         """Call the operation with the given args and kwargs.
@@ -66,6 +67,13 @@ class ServiceProxy(object):
         except ValueError:
             raise AttributeError('Service has no operation %r' % key)
         return OperationProxy(self, key)
+        
+    def __dir__(self):
+        """ Return the names of the operations. """
+        return list(super(ServiceProxy, self).__dir__()
+                    + list(self.__dict__)
+                    + list(self._binding.port_type.operations))
+                    # using list() on the dicts for Python 3 compatibility
 
 
 class Factory(object):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -49,6 +49,14 @@ def test_service_proxy_dir_operations():
     assert set(operations) == set(['GetLastTradePrice', 'GetLastTradePriceNoOutput']) 
 
 
+def test_operation_proxy_doc():
+    client_obj = client.Client('tests/wsdl_files/soap.wsdl')
+    assert (client_obj.service.GetLastTradePrice.__doc__ 
+            == 'GetLastTradePrice(tickerSymbol: xsd:string, '
+                                 'account: ns0:account, '
+                                 'country: ns0:country) -> price: xsd:float')
+
+
 def test_open_from_file_object():
     with open('tests/wsdl_files/soap_transport_err.wsdl', 'rb') as fh:
         client_obj = client.Client(fh)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,6 +43,12 @@ def test_service_proxy_non_existing():
         assert client_obj.service.NonExisting
 
 
+def test_service_proxy_dir_operations():
+    client_obj = client.Client('tests/wsdl_files/soap.wsdl')
+    operations = [op for op in dir(client_obj.service) if not op.startswith('_')]
+    assert set(operations) == set(['GetLastTradePrice', 'GetLastTradePriceNoOutput']) 
+
+
 def test_open_from_file_object():
     with open('tests/wsdl_files/soap_transport_err.wsdl', 'rb') as fh:
         client_obj = client.Client(fh)


### PR DESCRIPTION
This patch adds the operation names to `dir()` of `ServiceProxy` instances. Thus they are shown in auto-completion.