### PR TITLE
Add ability to handle defusexml security rules when parse xml

### DIFF
--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -115,12 +115,14 @@ class Client(object):
 
     def __init__(self, wsdl, wsse=None, transport=None,
                  service_name=None, port_name=None, plugins=None,
-                 strict=True, xml_huge_tree=False):
+                 strict=True, xml_huge_tree=False, forbid_dtd=False,
+                 forbid_entities=True):
         if not wsdl:
             raise ValueError("No URL given for the wsdl")
 
         self.transport = transport if transport is not None else Transport()
-        self.wsdl = Document(wsdl, self.transport, strict=strict)
+        self.wsdl = Document(wsdl, self.transport, strict=strict,
+                             forbid_dtd=forbid_dtd, forbid_entities=forbid_entities)
         self.wsse = wsse
         self.plugins = plugins if plugins is not None else []
         self.xml_huge_tree = xml_huge_tree

--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -109,7 +109,10 @@ class Client(object):
     :param plugins: a list of Plugin instances
     :param xml_huge_tree: disable lxml/libxml2 security restrictions and
                           support very deep trees and very long text content
-
+    :param forbid_dtd: disallow XML with a <!DOCTYPE> processing instruction
+    :type forbid_dtd: bool
+    :param forbid_entities: disallow XML with <!ENTITY> declarations inside the DTD
+    :type forbid_entities: bool
 
     """
 

--- a/src/zeep/loader.py
+++ b/src/zeep/loader.py
@@ -19,7 +19,7 @@ class ImportResolver(etree.Resolver):
 
 
 def parse_xml(content, transport, base_url=None, strict=True,
-              xml_huge_tree=False):
+              xml_huge_tree=False, forbid_dtd=False, forbid_entities=True):
     """Parse an XML string and return the root Element.
 
     :param content: The XML string
@@ -35,6 +35,10 @@ def parse_xml(content, transport, base_url=None, strict=True,
     :param xml_huge_tree: boolean to indicate if lxml should process very
       large XML content.
     :type strict: boolean
+    :param forbid_dtd: disallow XML with a <!DOCTYPE> processing instruction
+    :type forbid_dtd: bool
+    :param forbid_entities: disallow XML with <!ENTITY> declarations inside the DTD
+    :type forbid_entities: bool
     :returns: The document root
     :rtype: lxml.etree._Element
 
@@ -44,7 +48,8 @@ def parse_xml(content, transport, base_url=None, strict=True,
                              recover=recover, huge_tree=xml_huge_tree)
     parser.resolvers.add(ImportResolver(transport))
     try:
-        return fromstring(content, parser=parser, base_url=base_url)
+        return fromstring(content, parser=parser, base_url=base_url,
+                          forbid_dtd=forbid_dtd, forbid_entities=forbid_entities)
     except etree.XMLSyntaxError as exc:
         raise XMLSyntaxError(
             "Invalid XML content received (%s)" % exc.msg,
@@ -52,7 +57,7 @@ def parse_xml(content, transport, base_url=None, strict=True,
         )
 
 
-def load_external(url, transport, base_url=None, strict=True):
+def load_external(url, transport, base_url=None, strict=True, forbid_dtd=False, forbid_entities=True):
     """Load an external XML document.
 
     :param url:
@@ -62,7 +67,10 @@ def load_external(url, transport, base_url=None, strict=True):
       If false then the recover mode is enabled which tries to parse invalid
       XML as best as it can.
     :type strict: boolean
-
+    :param forbid_dtd: disallow XML with a <!DOCTYPE> processing instruction
+    :type forbid_dtd: bool
+    :param forbid_entities: disallow XML with <!ENTITY> declarations inside the DTD
+    :type forbid_entities: bool
     """
     if hasattr(url, 'read'):
         content = url.read()
@@ -70,7 +78,8 @@ def load_external(url, transport, base_url=None, strict=True):
         if base_url:
             url = absolute_location(url, base_url)
         content = transport.load(url)
-    return parse_xml(content, transport, base_url, strict=strict)
+    return parse_xml(content, transport, base_url, strict=strict,
+                     forbid_dtd=forbid_dtd, forbid_entities=forbid_entities)
 
 
 def absolute_location(location, base):

--- a/src/zeep/wsdl/wsdl.py
+++ b/src/zeep/wsdl/wsdl.py
@@ -49,10 +49,14 @@ class Document(object):
     :type base: str
     :param strict: Indicates if strict mode is enabled
     :type strict: bool
+    :param forbid_dtd: disallow XML with a <!DOCTYPE> processing instruction
+    :type forbid_dtd: bool
+    :param forbid_entities: disallow XML with <!ENTITY> declarations inside the DTD
+    :type forbid_entities: bool
 
     """
 
-    def __init__(self, location, transport, base=None, strict=True):
+    def __init__(self, location, transport, base=None, strict=True, forbid_dtd=False, forbid_entities=True):
         """Initialize a WSDL document.
 
         The root definition properties are exposed as entry points.
@@ -67,6 +71,8 @@ class Document(object):
 
         self.transport = transport
         self.strict = strict
+        self.forbid_dtd = forbid_dtd
+        self.forbid_entities = forbid_entities
 
         # Dict with all definition objects within this WSDL
         self._definitions = {}
@@ -137,7 +143,8 @@ class Document(object):
 
         """
         return load_external(
-            location, self.transport, self.location, strict=self.strict)
+            location, self.transport, self.location, strict=self.strict,
+            forbid_dtd=self.forbid_dtd, forbid_entities=self.forbid_entities)
 
     def _add_definition(self, definition):
         key = (definition.target_namespace, definition.location)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,5 +1,9 @@
+from defusedxml import EntitiesForbidden, DTDForbidden
+from pytest import raises as assert_raises
+
 from zeep.loader import parse_xml
 from tests.utils import DummyTransport
+
 
 def test_huge_text():
     # libxml2>=2.7.3 has XML_MAX_TEXT_LENGTH 10000000 without XML_PARSE_HUGE
@@ -12,3 +16,23 @@ def test_huge_text():
     """ % (u'\u00e5' * 10000001), DummyTransport(), xml_huge_tree=True)
 
     assert tree[0][0].text == u'\u00e5' * 10000001
+
+
+def test_allow_entities_and_dtd():
+    xml = u"""
+        <!DOCTYPE Author [
+          <!ENTITY writer "Donald Duck.">
+        ]>
+        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+         <s:Body>
+            <Author>&writer;</Author>
+         </s:Body>
+        </s:Envelope>
+    """
+    # DTD is allowed by default in defusexml so we follow this behaviour
+    assert_raises(DTDForbidden, parse_xml, xml, DummyTransport(), forbid_dtd=True)
+    assert_raises(EntitiesForbidden, parse_xml, xml, DummyTransport())
+
+    tree = parse_xml(xml, DummyTransport(), forbid_entities=False)
+
+    assert tree[0][0].tag == 'Author'

--- a/tests/test_wsdl.py
+++ b/tests/test_wsdl.py
@@ -1,5 +1,6 @@
 import io
 
+from defusedxml import EntitiesForbidden, DTDForbidden
 import pytest
 import requests_mock
 from lxml import etree
@@ -900,4 +901,41 @@ def test_wsdl_duplicate_tns(recwarn):
     transport = DummyTransport()
     transport.bind('http://tests.python-zeep.org/schema-2.wsdl', wsdl_2)
     document = wsdl.Document(wsdl_main, transport)
+    document.dump()
+
+
+def test_wsdl_dtd_entities_rules():
+    wsdl_declaration = u"""<!DOCTYPE Author [
+        <!ENTITY writer "Donald Duck.">
+        ]>
+        <wsdl:definitions
+        xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:tns="http://tests.python-zeep.org/xsd-main"
+        xmlns:mine="http://tests.python-zeep.org/xsd-secondary"
+        xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/"
+        targetNamespace="http://tests.python-zeep.org/xsd-main">
+        <wsdl:types>
+          <xsd:schema
+              targetNamespace="http://tests.python-zeep.org/xsd-main"
+              xmlns:tns="http://tests.python-zeep.org/xsd-main">
+            <xsd:element name="input" type="xsd:string"/>
+          </xsd:schema>
+        </wsdl:types>
+        <wsdl:message name="message-1">
+          <wsdl:part name="response" element="tns:input"/>
+        </wsdl:message>
+        <wsdl:portType name="TestPortType">
+          <wsdl:operation name="TestOperation1">
+            <wsdl:input message="message-1"/>
+          </wsdl:operation>
+        </wsdl:portType>
+        </wsdl:definitions>
+    """.strip()
+
+    transport = DummyTransport()
+    transport.bind('http://tests.python-zeep.org/schema-2.wsdl', wsdl_declaration)
+    pytest.raises(DTDForbidden, wsdl.Document, StringIO(wsdl_declaration), transport, forbid_dtd=True)
+    pytest.raises(EntitiesForbidden, wsdl.Document, StringIO(wsdl_declaration), transport)
+    document = wsdl.Document(StringIO(wsdl_declaration), transport, forbid_entities=False)
     document.dump()


### PR DESCRIPTION
Regard to issue [#391](https://github.com/mvantellingen/python-zeep/issues/391).

I really would like to use zeep in my project, because it has very friendly API and some other features, which is useful for me, but I can't do this, because zeep's Client don't have any tools to handle `defusexml` security rules, when using `fromstring` in the code. 

Generally, it's about behavior with `<!DOCUMENT>` and `<!ENTITIES>` tags in schema or xml. For example, I can't use `zeep` to work with `OpenTravel` wsdls, because they using DTD with entities inside wsdls. So, I've create PR, which add ability to handle this behaviour.

Will be happy to hear your things about it. Thanks!