### PR TITLE
using zeep with asyncio

### DIFF
--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -120,12 +120,10 @@ class Client(object):
             raise ValueError("No URL given for the wsdl")
 
         self.transport = transport if transport is not None else Transport()
-        if type(wsdl) == str:
-            self.wsdl = Document(wsdl, self.transport, strict=strict)
-        elif isinstance(wsdl, Document):
+        if isinstance(wsdl, Document):
             self.wsdl = wsdl
         else:
-            raise ValueError("Invalid value for wsdl")
+            self.wsdl = Document(wsdl, self.transport, strict=strict)
         self.wsse = wsse
         self.plugins = plugins if plugins is not None else []
         self.xml_huge_tree = xml_huge_tree

--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -120,7 +120,12 @@ class Client(object):
             raise ValueError("No URL given for the wsdl")
 
         self.transport = transport if transport is not None else Transport()
-        self.wsdl = Document(wsdl, self.transport, strict=strict)
+        if type(wsdl) == str:
+            self.wsdl = Document(wsdl, self.transport, strict=strict)
+        elif isinstance(wsdl, Document):
+            self.wsdl = wsdl
+        else:
+            raise ValueError("Invalid value for wsdl")
         self.wsse = wsse
         self.plugins = plugins if plugins is not None else []
         self.xml_huge_tree = xml_huge_tree


### PR DESCRIPTION
To address the issue with asyncio transport #381 
Blocking operation in this process is only used to fetch wsdl from network, if we move that part of work out of Client constructor, we can make asyncio transport working without breaking BC. 

With this approach, client creation looks like this:

```
    async def get_client(self, endpoint):
        async with aiohttp.ClientSession() as session:
            async with session.get(endpoint) as resp:
                transport = AsyncTransport(asyncio.get_event_loop())
                content = await resp.read()
                wsdl = Document(endpoint, transport, wsdl_content=content)
                client = Client(wsdl, transport=transport, strict=False)
                return client
```

A bit ugly but usable for now.