### PR TITLE
fix extension of base type containing choice by the type containing sequence.

### DIFF
--- a/src/zeep/xsd/types/complex.py
+++ b/src/zeep/xsd/types/complex.py
@@ -376,7 +376,7 @@ class ComplexType(AnyType):
             element = self._element.clone(self._element.name)
             if isinstance(base_element, OrderIndicator):
                 if isinstance(base_element, Choice):
-                    element.append(base_element)
+                    element.insert(0, base_element)
                 elif isinstance(self._element, Choice):
                     element = base_element.clone(self._element.name)
                     element.append(self._element)

--- a/src/zeep/xsd/types/complex.py
+++ b/src/zeep/xsd/types/complex.py
@@ -375,15 +375,14 @@ class ComplexType(AnyType):
 
             element = self._element.clone(self._element.name)
             if isinstance(base_element, OrderIndicator):
-                if isinstance(self._element, Choice):
+                if isinstance(base_element, Choice):
+                    element.append(base_element)
+                elif isinstance(self._element, Choice):
                     element = base_element.clone(self._element.name)
                     element.append(self._element)
                 elif isinstance(element, OrderIndicator):
                     for item in reversed(base_element):
                         element.insert(0, item)
-                elif isinstance(element, Group):
-                    for item in reversed(base_element):
-                        element.child.insert(0, item)
 
             elif isinstance(self._element, Group):
                 raise NotImplementedError('TODO')

--- a/src/zeep/xsd/types/complex.py
+++ b/src/zeep/xsd/types/complex.py
@@ -383,6 +383,9 @@ class ComplexType(AnyType):
                 elif isinstance(element, OrderIndicator):
                     for item in reversed(base_element):
                         element.insert(0, item)
+                elif isinstance(element, Group):
+                    for item in reversed(base_element):
+                        element.child.insert(0, item)
 
             elif isinstance(self._element, Group):
                 raise NotImplementedError('TODO')

--- a/tests/test_xsd_indicators_choice.py
+++ b/tests/test_xsd_indicators_choice.py
@@ -1222,6 +1222,52 @@ def test_choice_extend():
     assert value['_value_1'][1] == {'item-2-2': 'xabar'}
 
 
+def test_choice_extend_base():
+    schema = xsd.Schema(load_xml("""
+        <?xml version="1.0"?>
+        <schema
+                xmlns="http://www.w3.org/2001/XMLSchema"
+                xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                xmlns:tns="http://tests.python-zeep.org/"
+                elementFormDefault="qualified"
+                targetNamespace="http://tests.python-zeep.org/">
+            <xsd:complexType name="BaseType">
+                <xsd:choice>
+                    <xsd:element name="choice-1" type="xsd:string"/>
+                    <xsd:element name="choice-2" type="xsd:string"/>
+                </xsd:choice>
+            </xsd:complexType>
+            <xsd:element name="container">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="tns:BaseType">
+                            <xsd:sequence>
+                                <xsd:element name="container-1" type="xsd:string"/>
+                                <xsd:element name="container-2" type="xsd:string"/>
+                            </xsd:sequence>
+                            <xsd:attribute name="version" use="required" fixed="10.0.1.2"/>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+        </schema>
+    """))
+
+    element = schema.get_element('ns0:container')
+    node = load_xml("""
+        <ns0:container xmlns:ns0="http://tests.python-zeep.org/" version="10.0.1.2">
+          <ns0:container-1>foo</ns0:container-1>
+          <ns0:container-2>bar</ns0:container-2>
+          <ns0:choice-1>foo</ns0:choice-1>
+        </ns0:container>
+    """)
+    value = element.parse(node, schema)
+
+    assert value['container-1'] == 'foo'
+    assert value['container-2'] == 'bar'
+    assert value['choice-1'] == 'foo'
+
+
 def test_nested_choice():
     schema = xsd.Schema(load_xml("""
             <?xml version="1.0"?>

--- a/tests/test_xsd_indicators_choice.py
+++ b/tests/test_xsd_indicators_choice.py
@@ -1256,9 +1256,9 @@ def test_choice_extend_base():
     element = schema.get_element('ns0:container')
     node = load_xml("""
         <ns0:container xmlns:ns0="http://tests.python-zeep.org/" version="10.0.1.2">
+          <ns0:choice-1>foo</ns0:choice-1>
           <ns0:container-1>foo</ns0:container-1>
           <ns0:container-2>bar</ns0:container-2>
-          <ns0:choice-1>foo</ns0:choice-1>
         </ns0:container>
     """)
     value = element.parse(node, schema)


### PR DESCRIPTION
This is similar to #257 but from the other side.
If you try to extend type with choice element by the type with sequence all items from choice would be copied to sequence and became flatten.
Look into the schema from test_choice_extend_base test in all became clear.