### PR TITLE
Deal with Nil on a complexType with simpleContent

### DIFF
--- a/src/zeep/xsd/types/simple.py
+++ b/src/zeep/xsd/types/simple.py
@@ -4,7 +4,7 @@ import six
 from lxml import etree
 
 from zeep.exceptions import ValidationError
-from zeep.xsd.const import xsd_ns
+from zeep.xsd.const import Nil, xsd_ns, xsi_ns
 from zeep.xsd.types.any import AnyType
 
 logger = logging.getLogger(__name__)
@@ -68,6 +68,9 @@ class AnySimpleType(AnyType):
             '%s.pytonvalue() not implemented' % self.__class__.__name__)
 
     def render(self, parent, value, xsd_type=None, render_path=None):
+        if value is Nil:
+            parent.set(xsi_ns('nil'), 'true')
+            return
         parent.text = self.xmlvalue(value)
 
     def signature(self, schema=None, standalone=True):

--- a/tests/test_xsd_complex_types.py
+++ b/tests/test_xsd_complex_types.py
@@ -295,3 +295,38 @@ def test_xml_unparsed_elements():
     obj = container_elm.parse(expected[0], schema)
     assert obj.item == 'bar'
     assert obj._raw_elements
+
+
+def test_xml_simple_content_nil():
+    schema = xsd.Schema(load_xml("""
+    <?xml version="1.0"?>
+    <schema xmlns="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://tests.python-zeep.org/"
+            targetNamespace="http://tests.python-zeep.org/"
+            elementFormDefault="qualified">
+      <element name="container" nillable="true">
+        <complexType>
+          <simpleContent>
+              <restriction base="string">
+                <maxLength value="1000"/>
+              </restriction>
+          </simpleContent>
+        </complexType>
+      </element>
+    </schema>
+    """))
+    schema.set_ns_prefix('tns', 'http://tests.python-zeep.org/')
+    container_elm = schema.get_element('tns:container')
+    obj = container_elm(xsd.Nil)
+    result = render_node(container_elm, obj)
+
+    expected = """
+      <document>
+        <ns0:container xmlns:ns0="http://tests.python-zeep.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      </document>
+    """
+    result = render_node(container_elm, obj)
+    assert_nodes_equal(result, expected)
+
+    obj = container_elm.parse(result[0], schema)
+    assert obj._value_1 is None


### PR DESCRIPTION
When Nil is set on an element which is built up from a complexType with simpleContent don't render it as a element with the text content 'Nil', but as the xsi:nil attribute on the element.