### PR TITLE
Fix Error when a name contains a space

### DIFF
--- a/src/zeep/utils.py
+++ b/src/zeep/utils.py
@@ -36,7 +36,7 @@ def as_qname(value, nsmap, target_namespace=None):
         return etree.QName(namespace, local)
 
     if target_namespace:
-        return etree.QName(target_namespace, value)
+        return etree.QName(target_namespace, value.strip())
 
     if nsmap.get(None):
         return etree.QName(nsmap[None], value)


### PR DESCRIPTION
I found an API that contains spaces in their fields names like:

<>NAME <>

and generates this error when the XML was parsing:
File "src/lxml/apihelpers.pxi", line 1631, in lxml.etree._tagValidOrRaise (src/lxml/etree.c:35382)
ValueError: Invalid tag name u'NAME '

This fix strip all spaces in the field names.