### PR TITLE
fix TypeError: string indices must be integers

### DIFF
--- a/src/zeep/xsd/types/complex.py
+++ b/src/zeep/xsd/types/complex.py
@@ -2,6 +2,7 @@ import copy
 import logging
 from collections import OrderedDict, deque
 from itertools import chain
+import six
 
 from cached_property import threaded_cached_property
 
@@ -221,7 +222,7 @@ class ComplexType(AnyType):
 
         # Render attributes
         for name, attribute in self.attributes:
-            attr_value = value[name] if name in value else NotSet
+            attr_value = value[name] if name in value and not isinstance(value, six.string_types) else NotSet
             child_path = render_path + [name]
             attribute.render(parent, attr_value, child_path)
 


### PR DESCRIPTION
when the request type is defined as string.
And the request string looks like 
`
<query>
  <id>1</id>
  <otherno>1</otherno> 
</query>
`

zeep will raise exception:

Traceback (most recent call last):
  File "D:/workspace/SLAF/SLAF_trunk/common_lib/SinosigCommonTALib/zeep_soap.py", line 110, in <module>
    r = client.service.queryRequest(content)
  File "C:\python\python36\lib\site-packages\zeep\client.py", line 41, in __call__
    self._op_name, args, kwargs)
  File "C:\python\python36\lib\site-packages\zeep\wsdl\bindings\soap.py", line 110, in send
    options=options)
  File "C:\python\python36\lib\site-packages\zeep\wsdl\bindings\soap.py", line 68, in _create
    serialized = operation_obj.create(*args, **kwargs)
  File "C:\python\python36\lib\site-packages\zeep\wsdl\definitions.py", line 197, in create
    return self.input.serialize(*args, **kwargs)
  File "C:\python\python36\lib\site-packages\zeep\wsdl\messages\soap.py", line 64, in serialize
    self.body.render(body, body_value)
  File "C:\python\python36\lib\site-packages\zeep\xsd\elements\element.py", line 191, in render
    self._render_value_item(parent, value, render_path)
  File "C:\python\python36\lib\site-packages\zeep\xsd\elements\element.py", line 215, in _render_value_item
    return self.type.render(node, value, None, render_path)
  File "C:\python\python36\lib\site-packages\zeep\xsd\types\complex.py", line 255, in render
    element.render(parent, element_value, child_path)
  File "C:\python\python36\lib\site-packages\zeep\xsd\elements\indicators.py", line 241, in render
    element.render(parent, element_value, child_path)
  File "C:\python\python36\lib\site-packages\zeep\xsd\elements\element.py", line 191, in render
    self._render_value_item(parent, value, render_path)
  File "C:\python\python36\lib\site-packages\zeep\xsd\elements\element.py", line 215, in _render_value_item
    return self.type.render(node, value, None, render_path)
  File "C:\python\python36\lib\site-packages\zeep\xsd\types\complex.py", line 225, in render
    attr_value = value[name] if name in value else NotSet
TypeError: string indices must be integers

so should check that value is not a string.
it works for me. Guess there may have better solution.