### PR TITLE
UnicodeError when faultstring is encoded

### DIFF
--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -282,7 +282,7 @@ class Soap11Binding(SoapBinding):
         def get_text(name):
             child = fault_node.find(name)
             if child is not None:
-                return child.text
+                return unicode(child.text).encode('utf-8')
 
         raise Fault(
             message=get_text('faultstring'),


### PR DESCRIPTION
When a service returns encoded charset in `faultstring`, it raises an
UnicodeError while creating an instance of the `Fault` object.

```
In [5]: r = c.service['solicAutorizDownloadArqAnual'](iCdTpDoc=209, _soapheaders=[l.header])
---------------------------------------------------------------------------
Fault                                     Traceback (most recent call last)
<ipython-input-5-b9906d0dc723> in <module>()
----> 1 r = c.service['solicAutorizDownloadArqAnual'](iCdTpDoc=209, _soapheaders=[l.header])

/Users/wilson/dev/cvmweb/lib/python2.7/site-packages/zeep/client.pyc in __call__(self, *args, **kwargs)
     43         return self._proxy._binding.send(
     44             self._proxy._client, self._proxy._binding_options,
---> 45             self._op_name, args, kwargs)
     46
     47

/Users/wilson/dev/cvmweb/lib/python2.7/site-packages/zeep/wsdl/bindings/soap.py in send(self, client, options, operation, args, kwargs)
    119             return response
    120
--> 121         return self.process_reply(client, operation_obj, response)
    122
    123     def process_reply(self, client, operation, response):

/Users/wilson/dev/cvmweb/lib/python2.7/site-packages/zeep/wsdl/bindings/soap.py in process_reply(self, client, operation, response)
    184             'soap-env:Body/soap-env:Fault', namespaces=self.nsmap)
    185         if response.status_code != 200 or fault_node is not None:
--> 186             return self.process_error(doc, operation)
    187
    188         result = operation.process_reply(doc)

/Users/wilson/dev/cvmweb/lib/python2.7/site-packages/zeep/wsdl/bindings/soap.py in process_error(self, doc, operation)
    290             code=get_text('faultcode'),
    291             actor=get_text('faultactor'),
--> 292             detail=fault_node.find('detail'))
    293
    294     def _set_http_headers(self, serialized, operation):

<type 'str'>: (<type 'exceptions.UnicodeEncodeError'>, UnicodeEncodeError('ascii', u'Usu\xe1rio atingiu o n\xfamero m\xe1ximo de autoriza\xe7\xf5es para download permitido. Autoriza\xe7\xe3o n\xe3o concedida.', 3, 4, 'ordinal not in range(128)'))
```

This happens in the `get_text` function call to `faultstring`.
This exception is avoided by converting the `child.text` call to unicode.

```python
def get_text(name):
    child = fault_node.find(name)
    if child is not None:
        return unicode(child.text).encode('utf-8')
```