### PR TITLE
Add check to handle simple return values.

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -50,5 +50,4 @@ Contributors
 * Raymond Piller
 * Zoltan Benedek
 * Øyvind Heddeland Instefjord
-
-
+* Adam J. Varga

--- a/src/zeep/wsdl/messages/soap.py
+++ b/src/zeep/wsdl/messages/soap.py
@@ -101,9 +101,13 @@ class SoapMessage(ConcreteMessage):
             return result
 
         result = result.body
-        if result is None or len(result) == 0:
-            return None
-        elif len(result) > 1:
+
+        if hasattr(result, '__len__'):
+            if len(result) == 0:
+                return None
+            elif len(result) > 1:
+                return result
+        else:
             return result
 
         # Check if we can remove the wrapping object to make the return value


### PR DESCRIPTION
Previously, returned values that didn't have a 'len' method raised TypeError:
Example:
The corresponding WSDL section:
<xsd:element name="DisconnectResponse" nillable="false" type="tns:int"/>
After calling 'disconnect':
TypeError: object of type 'int' has no len()