### PR TITLE
Update the DateTime builtin type to accept strings

### DIFF
--- a/src/zeep/xsd/types/builtins.py
+++ b/src/zeep/xsd/types/builtins.py
@@ -124,6 +124,10 @@ class DateTime(BuiltinType, AnySimpleType):
     @check_no_collection
     def xmlvalue(self, value):
 
+        if isinstance(value, six.string_types):
+            # Make sure the string is a valid ISO date/time
+            value = isodate.parse_datetime(value)
+
         # Bit of a hack, since datetime is a subclass of date we can't just
         # test it with an isinstance(). And actually, we should not really
         # care about the type, as long as it has the required attributes

--- a/tests/test_xsd_builtins.py
+++ b/tests/test_xsd_builtins.py
@@ -131,6 +131,18 @@ class TestDateTime:
         value = value.astimezone(pytz.timezone('Europe/Amsterdam'))
         assert instance.xmlvalue(value) == '2016-03-04T22:14:42+01:00'
 
+        value = '2016-03-04T21:14:42'
+        assert instance.xmlvalue(value) == '2016-03-04T21:14:42'
+
+        value = '2016-03-04T21:14:42Z'
+        assert instance.xmlvalue(value) == '2016-03-04T21:14:42Z'
+
+        value = '2016-03-04T21:14:42.123456Z'
+        assert instance.xmlvalue(value) == '2016-03-04T21:14:42.123456Z'
+
+        value = '2016-03-04T22:14:42+01:00'
+        assert instance.xmlvalue(value) == '2016-03-04T22:14:42+01:00'
+
     def test_pythonvalue(self):
         instance = builtins.DateTime()
         value = datetime.datetime(2016, 3, 4, 21, 14, 42)


### PR DESCRIPTION
This is related to #601 and allows DateTime to accept ISO formatted strings