### PR TITLE
Use __getattr__() for CompoundValue instead of __getattribute__()

### DIFF
--- a/src/zeep/xsd/valueobjects.py
+++ b/src/zeep/xsd/valueobjects.py
@@ -131,9 +131,7 @@ class CompoundValue(object):
             return super(CompoundValue, self).__setattr__(key, value)
         self.__values__[key] = value
 
-    def __getattribute__(self, key):
-        if key.startswith('__') or key in ('_xsd_type', '_xsd_elm'):
-            return super(CompoundValue, self).__getattribute__(key)
+    def __getattr__(self, key):
         try:
             return self.__values__[key]
         except KeyError:


### PR DESCRIPTION
The latter is a bit less efficient, and triggered for every attribute, while __getattr__() is only called for missing attributes - which is exactly what is needed to read the SOAP object attributes as normal object attributes.

The build errors are due to a version conflict with aiohttp, and not caused by this patch.