### PR TITLE
Aio fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: install clean test retest coverage docs
 
 install:
-	pip install -e .[docs,test,async]
+	pip install -e .[docs,test,async,tornado]
 	pip install bumpversion twine wheel
 
 lint:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ docs_require = [
 ]
 
 tornado_require = [
-    'tornado>=4.0.2'
+    'tornado>=4.0.2,<5'
 ]
 
 async_require = []  # see below
@@ -49,7 +49,7 @@ tests_require = [
 
 if sys.version_info > (3, 4, 2):
     async_require.append('aiohttp>=1.0')
-    tests_require.append('aioresponses>=0.1.3')
+    tests_require.append('aioresponses>=0.4.1')
 
 
 with open('README.rst') as fh:

--- a/src/zeep/asyncio/transport.py
+++ b/src/zeep/asyncio/transport.py
@@ -52,6 +52,11 @@ class AsyncTransport(Transport):
 
     def _load_remote_data(self, url):
         result = None
+        if self.loop.is_running():
+            raise RuntimeError(
+                "WSDL loading is not asynchronous yet. "
+                "Instantiate the zeep client outside the asyncio event loop."
+            )
 
         async def _load_remote_data_async():
             nonlocal result

--- a/src/zeep/asyncio/transport.py
+++ b/src/zeep/asyncio/transport.py
@@ -46,7 +46,9 @@ class AsyncTransport(Transport):
 
     def __del__(self):
         if self._close_session:
-            self.session.close()
+            # aiohttp.ClientSession.close() is async,
+            # call the underlying sync function instead.
+            self.session.connector.close()
 
     def _load_remote_data(self, url):
         result = None

--- a/src/zeep/asyncio/transport.py
+++ b/src/zeep/asyncio/transport.py
@@ -48,7 +48,8 @@ class AsyncTransport(Transport):
         if self._close_session:
             # aiohttp.ClientSession.close() is async,
             # call the underlying sync function instead.
-            self.session.connector.close()
+            if self.session.connector is not None:
+                self.session.connector.close()
 
     def _load_remote_data(self, url):
         result = None

--- a/src/zeep/asyncio/transport.py
+++ b/src/zeep/asyncio/transport.py
@@ -14,6 +14,12 @@ from zeep.transports import Transport
 from zeep.utils import get_version
 from zeep.wsdl.utils import etree_to_string
 
+try:
+    from async_timeout import timeout as aio_timeout  # Python 3.6+
+except ImportError:
+    from aiohttp import Timeout as aio_timeout  # Python 3.5, aiohttp < 3
+
+
 __all__ = ['AsyncTransport']
 
 
@@ -47,7 +53,7 @@ class AsyncTransport(Transport):
 
         async def _load_remote_data_async():
             nonlocal result
-            with aiohttp.Timeout(self.load_timeout):
+            with aio_timeout(self.load_timeout):
                 response = await self.session.get(url)
                 result = await response.read()
                 try:
@@ -65,7 +71,7 @@ class AsyncTransport(Transport):
 
     async def post(self, address, message, headers):
         self.logger.debug("HTTP Post to %s:\n%s", address, message)
-        with aiohttp.Timeout(self.operation_timeout):
+        with aio_timeout(self.operation_timeout):
             response = await self.session.post(
                 address, data=message, headers=headers)
             self.logger.debug(

--- a/src/zeep/cache.py
+++ b/src/zeep/cache.py
@@ -39,6 +39,9 @@ class InMemoryCache(Base):
 
     def add(self, url, content):
         logger.debug("Caching contents of %s", url)
+        if not isinstance(content, (str, bytes)):
+            raise TypeError(
+                "a bytes-like object is required, not {}".format(type(content).__name__))
         self._cache[url] = (datetime.datetime.utcnow(), content)
 
     def get(self, url):

--- a/tests/test_asyncio_transport.py
+++ b/tests/test_asyncio_transport.py
@@ -5,6 +5,7 @@ from lxml import etree
 from pretend import stub
 
 from zeep import asyncio, exceptions
+from zeep.cache import InMemoryCache
 
 
 @pytest.mark.requests
@@ -22,6 +23,29 @@ def test_load(event_loop):
         m.get('http://tests.python-zeep.org/test.xml', body='x')
         result = transport.load('http://tests.python-zeep.org/test.xml')
         assert result == b'x'
+
+
+@pytest.mark.requests
+def test_load_cache(event_loop):
+    cache = InMemoryCache()
+    transport = asyncio.AsyncTransport(loop=event_loop, cache=cache)
+
+    with aioresponses() as m:
+        m.get('http://tests.python-zeep.org/test.xml', body='x')
+        result = transport.load('http://tests.python-zeep.org/test.xml')
+        assert result == b'x'
+
+    assert cache.get('http://tests.python-zeep.org/test.xml') == b'x'
+
+
+def test_cache_checks_type():
+    cache = InMemoryCache()
+
+    async def foo():
+        pass
+
+    with pytest.raises(TypeError):
+        cache.add('x', foo())
 
 
 @pytest.mark.requests

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,12 @@ envlist = py27,py33,py34,py35,py36,pypy
 
 [testenv]
 extras = 
-    test 
+    test
     xmlsec
     py{35,36}: async
+    py{35,36}: tornado
 deps = 
-    py{35,36}: aioresponses==0.1.3
+    py{35,36}: aioresponses==0.4.1
     py{35,36}: pytest-asyncio==0.5.0
 commands = coverage run --parallel -m pytest {posargs}
 


### PR DESCRIPTION
* Fix aiohttp 3.0 support (uses timeout code from stdlib)
* Fix missing await for the `session.close()`

The latest zeep still breaks on Tornado 5.x, since Tornado 5 already starts a asyncio loop.