### PR TITLE
Process errors prior to verifying wsse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Vim #
+*.swp
+
 *.egg-info
 *.pyc
 __pycache__

--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -172,9 +172,6 @@ class SoapBinding(Binding):
             if process_xop(doc, message_pack):
                 message_pack = None
 
-        if client.wsse:
-            client.wsse.verify(doc)
-
         doc, http_headers = plugins.apply_ingress(
             client, doc, response.headers, operation)
 
@@ -184,6 +181,9 @@ class SoapBinding(Binding):
             'soap-env:Body/soap-env:Fault', namespaces=self.nsmap)
         if response.status_code != 200 or fault_node is not None:
             return self.process_error(doc, operation)
+
+        if client.wsse:
+            client.wsse.verify(doc)
 
         result = operation.process_reply(doc)
 


### PR DESCRIPTION
Attempting an invalid Login() action on a service will not have a valid security header. I moved the error processing above the wsse verification to properly handle the fault codes.