### PR TITLE
Fixed handling of minOrrurs of elements with @ref inside of choice

### DIFF
--- a/src/zeep/xsd/visitor.py
+++ b/src/zeep/xsd/visitor.py
@@ -319,6 +319,10 @@ class SchemaVisitor(object):
         # be present. Short circuit that here.
         # Ref is prohibited on global elements (parent = schema)
         if not is_global:
+            # Naive workaround to mark fields which are part of a choice element
+            # as optional
+            if parent.tag == tags.choice:
+                min_occurs = 0
             result = self.process_reference(
                 node, min_occurs=min_occurs, max_occurs=max_occurs)
             if result:
@@ -350,11 +354,6 @@ class SchemaVisitor(object):
                 xsd_type = self._get_type(node_type.text)
             else:
                 xsd_type = xsd_types.AnyType()
-
-        # Naive workaround to mark fields which are part of a choice element
-        # as optional
-        if parent.tag == tags.choice:
-            min_occurs = 0
 
         nillable = node.get('nillable') == 'true'
         default = node.get('default')

--- a/tests/test_xsd_parse.py
+++ b/tests/test_xsd_parse.py
@@ -1,9 +1,10 @@
+import pytest
 import datetime
 
 from lxml import etree
 
 from tests.utils import load_xml
-from zeep import xsd
+from zeep import exceptions,xsd
 from zeep.xsd.schema import Schema
 
 
@@ -462,3 +463,53 @@ def test_xsd_missing_localname():
     """))
 
     schema.get_element('{http://tests.python-zeep.org/}container')
+
+def test_xsd_choice_with_references():
+    schema = xsd.Schema(load_xml("""
+            <xsd:schema
+                xmlns:zeep="http://tests.python-zeep.org/"
+                xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                targetNamespace="http://tests.python-zeep.org/">
+
+              <xsd:element name="el1" type="xsd:string"/>
+              <xsd:element name="el2" type="xsd:string"/>
+
+              <xsd:element name="container">
+        		<xsd:complexType>
+        			<xsd:sequence>
+        				<xsd:choice>
+        					<xsd:element ref="zeep:el1"/>
+        					<xsd:element ref="zeep:el2"/>
+        					<xsd:element name="el3" type="xsd:string"/>
+        				</xsd:choice>
+        			</xsd:sequence>
+        		</xsd:complexType>
+              </xsd:element>
+
+             </xsd:schema>
+        """))
+    schema.set_ns_prefix('tns', 'http://tests.python-zeep.org/')
+    container_elm = schema.get_element('tns:container')
+    obj = container_elm()
+
+    xml = load_xml(b"""
+        <ns0:container xmlns:ns0="http://tests.python-zeep.org/">
+          <ns0:BAD_ELEMENT>BAD VALUE</ns0:BAD_ELEMENT>
+        </ns0:container>
+    """)
+
+    elm = schema.get_element('{http://tests.python-zeep.org/}container')
+
+    with pytest.raises(exceptions.XMLParseError) as exc:
+        result = elm.parse(xml, schema)
+    assert 'BAD_ELEMENT' in str(exc)
+
+    xml = load_xml(b"""
+        <ns0:container xmlns:ns0="http://tests.python-zeep.org/">
+          <ns0:el2>value2</ns0:el2>
+        </ns0:container>
+    """)
+
+    result = elm.parse(xml, schema)
+
+    assert result.el2 == 'value2'

--- a/tests/test_xsd_parse.py
+++ b/tests/test_xsd_parse.py
@@ -489,8 +489,6 @@ def test_xsd_choice_with_references():
              </xsd:schema>
         """))
     schema.set_ns_prefix('tns', 'http://tests.python-zeep.org/')
-    container_elm = schema.get_element('tns:container')
-    obj = container_elm()
 
     xml = load_xml(b"""
         <ns0:container xmlns:ns0="http://tests.python-zeep.org/">

--- a/tests/test_xsd_visitor.py
+++ b/tests/test_xsd_visitor.py
@@ -633,5 +633,6 @@ def test_referenced_elements_in_choice():
     schema = parse_schema_node(node)
     container_element = schema.get_element('{http://tests.python-zeep.org/}container')
     for el_name, sub_element in container_element.type.elements:
+        assert el_name in ('el1', 'el2', 'el3')
         assert sub_element.min_occurs == 0
         assert sub_element.is_optional == True

--- a/tests/test_xsd_visitor.py
+++ b/tests/test_xsd_visitor.py
@@ -605,3 +605,33 @@ def test_strip_spaces_from_qname():
     xsd_element = schema.get_element('{http://tests.python-zeep.org/}container')
     elm = xsd_element(THIS_TOO='okay')
     assert elm.THIS_TOO == 'okay'
+
+def test_referenced_elements_in_choice():
+    node = load_xml("""
+        <xsd:schema
+            xmlns:zeep="http://tests.python-zeep.org/"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://tests.python-zeep.org/">
+
+          <xsd:element name="el1" type="xsd:string"/>
+          <xsd:element name="el2" type="xsd:string"/>
+
+          <xsd:element name="container">
+    		<xsd:complexType>
+    			<xsd:sequence>
+    				<xsd:choice>
+    					<xsd:element ref="zeep:el1"/>
+    					<xsd:element ref="zeep:el2"/>
+    					<xsd:element name="el3" type="xsd:string"/>
+    				</xsd:choice>
+    			</xsd:sequence>
+    		</xsd:complexType>
+          </xsd:element>
+
+         </xsd:schema>
+    """)
+    schema = parse_schema_node(node)
+    container_element = schema.get_element('{http://tests.python-zeep.org/}container')
+    for el_name, sub_element in container_element.type.elements:
+        assert sub_element.min_occurs == 0
+        assert sub_element.is_optional == True


### PR DESCRIPTION
Hi,

when handling the XSD with referenced elements inside of choice the min_occurs was set to 1 and led to parsing errors. Since the code 
'''
            if parent.tag == tags.choice:
                min_occurs = 0
'''

was executed AFTER the element reference was resolved, the parent tag was always "schema" and never "choice". I moved the mic_occurs to the place where it is executed before the reference is resolved.

I hope the FIX is right and you can accept the Pull Request.

Cheers 
