### PR TITLE
 Add support for different signing and verification certificates

### DIFF
--- a/src/zeep/wsse/signature.py
+++ b/src/zeep/wsse/signature.py
@@ -51,7 +51,7 @@ class MemorySignature(object):
         self.signing_key_data = signing_key_data
         self.signing_cert_data = signing_cert_data
         self.password = password
-        self.signature_verification_cert_data = signature_verification_cert_data
+        self.signature_verification_cert_data = signature_verification_cert_data if signature_verification_cert_data is not None else signing_cert_data
 
     def apply(self, envelope, headers):
         key = _make_sign_key(self.signing_key_data, self.signing_cert_data, self.password)

--- a/src/zeep/wsse/signature.py
+++ b/src/zeep/wsse/signature.py
@@ -45,20 +45,21 @@ def _make_verify_key(cert_data):
 class MemorySignature(object):
     """Sign given SOAP envelope with WSSE sig using given key and cert."""
 
-    def __init__(self, key_data, cert_data, password=None):
+    def __init__(self, signing_key_data, signing_cert_data, password=None, signature_verification_cert_data=None):
         check_xmlsec_import()
 
-        self.key_data = key_data
-        self.cert_data = cert_data
+        self.signing_key_data = signing_key_data
+        self.signing_cert_data = signing_cert_data
         self.password = password
+        self.signature_verification_cert_data = signature_verification_cert_data
 
     def apply(self, envelope, headers):
-        key = _make_sign_key(self.key_data, self.cert_data, self.password)
+        key = _make_sign_key(self.signing_key_data, self.signing_cert_data, self.password)
         _sign_envelope_with_key(envelope, key)
         return envelope, headers
 
     def verify(self, envelope):
-        key = _make_verify_key(self.cert_data)
+        key = _make_verify_key(self.signature_verification_cert_data)
         _verify_envelope_with_key(envelope, key)
         return envelope
 
@@ -66,9 +67,13 @@ class MemorySignature(object):
 class Signature(MemorySignature):
     """Sign given SOAP envelope with WSSE sig using given key file and cert file."""
 
-    def __init__(self, key_file, certfile, password=None):
+    def __init__(self, signing_key_file, signing_certificate_file, password=None, signature_verification_file=None):
         super(Signature, self).__init__(
-            _read_file(key_file), _read_file(certfile), password)
+            _read_file(signing_key_file),
+            _read_file(signing_certificate_file),
+            password,
+            _read_file(signature_verification_file if signature_verification_file is not None else signing_certificate_file)
+        )
 
 
 def check_xmlsec_import():


### PR DESCRIPTION
I added support for situations where the signing certificate is different from the response signature verification certificate.
The code added will is fully compatible with older versions, since the signature verification certificate will only be used if it is passed to the constructor - otherwise the signing certificate is used (same as used to be before the change).