### PR TITLE
Make the 'utils.get_media_type' function return a lower case value.

### DIFF
--- a/src/zeep/utils.py
+++ b/src/zeep/utils.py
@@ -86,4 +86,4 @@ def detect_soap_env(envelope):
 def get_media_type(value):
     """Parse a HTTP content-type header and return the media-type"""
     main_value, parameters = cgi.parse_header(value)
-    return main_value
+    return main_value.lower()


### PR DESCRIPTION
Some servers might return mixed or title case values in the 'Content-Type' header. This can eventually create response parsing errors as it in fact has happened to me with the "Multipart/Related" media type. This media type is properly handled by the 'process_reply' method in 'wsdl.bindings.soap' but it is evaluated as "multipart/related" which makes the response parsing fail. My current workaround is to create a custom 'Transport' class and override the 'post_xml' method to modify the response headers, but this would be unnecessary if this fix is implemented.