### PR TITLE
content_type check made to not case sensitive

### DIFF
--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -157,7 +157,7 @@ class SoapBinding(Binding):
 
         # If the reply is a multipart/related then we need to retrieve all the
         # parts
-        if media_type == 'multipart/related':
+        if media_type.lower() == 'multipart/related':
             decoder = MultipartDecoder(
                 response.content, content_type, response.encoding or 'utf-8')
             content = decoder.parts[0].content


### PR DESCRIPTION
This was giving me errors and it seems that content type is not case sensitive, thus the proposed fix.

https://www.w3.org/Protocols/rfc1341/4_Content-Type.html

The type, subtype, and parameter names are not case sensitive. For example, TEXT, Text, and TeXt are all equivalent. Parameter values are normally case sensitive, but certain parameters are interpreted to be case- insensitive, depending on the intended use. (For example, multipart boundaries are case-sensitive, but the "access- type" for message/External-body is not case-sensitive.)