### PR TITLE
Add __iter__ method to ServiceProxy class

### DIFF
--- a/src/zeep/proxy.py
+++ b/src/zeep/proxy.py
@@ -70,6 +70,10 @@ class ServiceProxy(object):
         except KeyError:
             raise AttributeError('Service has no operation %r' % key)
 
+    def __iter__(self):
+        """ Return iterator over the services and their callables. """
+        return iter(self._operations.items())
+
     def __dir__(self):
         """ Return the names of the operations. """
         return list(itertools.chain(


### PR DESCRIPTION
This makes it possible to iterate over methods defined in the
WSDL, adding more flexibility to call out methods programmatically.