### PR TITLE
Bunch of improvements to Transport docs

### DIFF
--- a/docs/transport.rst
+++ b/docs/transport.rst
@@ -74,6 +74,32 @@ seconds:
         transport=transport)
 
 
+Using HTTP or SOCKS Proxy
+-------------------------
+
+By default, zeep uses ``requests`` as transport layer, which allows to
+define proxies using the ``proxies`` attribute of :class:`requests.Session`:
+
+.. code-block:: python
+
+    from zeep.import Client
+
+    client = Client(
+        'http://my.own.sslhost.local/service?WSDL')
+
+    client.transport.session.proxies = {
+        # Utilize for all http/https connections
+        'http': 'foo.bar:3128',
+        'https': 'foo.bar:3128',
+        # Utilize for certain URL
+        'http://specific.host.example': 'foo.bar:8080',
+        # Or use socks5 proxy (requires requests[socks])
+        'https://socks5-required.example': 'socks5://foo.bar:8888',
+    }
+
+In order to use **SOCKS** proxies, requests needs to be installed with
+additional packages (for example ``pip install -U requests[socks]``).
+
 .. _transport_caching:
 
 Caching

--- a/docs/transport.rst
+++ b/docs/transport.rst
@@ -41,8 +41,14 @@ To **disable SSL verification** (not recommended!) you will need to set
     session = Session()
     session.verify = False
 
+Or even simpler way:
+
+.. code-block:: python
+
+    client.transport.session.verify = False
+
 Remember: this should be only done for testing purposes. Python's ``urllib3``
-will warn you with a InsecureRequestWarning.
+will warn you with a ``InsecureRequestWarning``.
 
 See :class:`requests.Session` for further details.
 

--- a/docs/transport.rst
+++ b/docs/transport.rst
@@ -1,11 +1,16 @@
 Transports
 ==========
-If you need to change options like cache, timeout or SSL verification you will
-need to create an instance of the Transport class yourself.
+If you need to change options like cache, timeout or TLS (or SSL) verification
+you will need to create an instance of the Transport class yourself.
 
-SSL verification
+.. note::
+    Secure Sockets Layer (SSL) has been deprecated in favor of Transport
+    Layer Security (**TLS**). SSL 2.0 was prohibited in 2011 and SSL 3.0
+    in June 2015.
+
+TLS verification
 ----------------
-If you need to verify the SSL connection (in case you have a self-signed
+If you need to verify the TLS connection (in case you have a self-signed
 certificate for your host), the best way is to create a
 :class:`requests.Session` instance and add the information to that Session,
 so it keeps persistent:
@@ -31,9 +36,9 @@ so it keeps persistent:
     different files, you must combine them manually into one.
 
 Alternatively, instead of using ``session.verify`` you can use
-``session.cert`` if you just want to use an SSL client certificate.
+``session.cert`` if you just want to use an TLS client certificate.
 
-To **disable SSL verification** (not recommended!) you will need to set
+To **disable TLS verification** (not recommended!) you will need to set
 ``verify`` to ``False``.
 
 .. code-block:: python

--- a/docs/transport.rst
+++ b/docs/transport.rst
@@ -23,11 +23,12 @@ so it keeps persistent:
         'http://my.own.sslhost.local/service?WSDL',
         transport=transport)
 
-.. HINT::
-Make sure that the certificate you refer to is a CA_BUNDLE, meaning it
-contains a root CA and an intermediate CA. Accepted are only X.509 ASCII
-files (file extension ``.pem``, sometimes ``.crt``). If you have two
-different files, you must combine them manually into one.
+
+.. hint::
+    Make sure that the certificate you refer to is a CA_BUNDLE, meaning it
+    contains a root CA and an intermediate CA. Accepted are only X.509 ASCII
+    files (file extension ``.pem``, sometimes ``.crt``). If you have two
+    different files, you must combine them manually into one.
 
 Alternatively, instead of using ``session.verify`` you can use
 ``session.cert`` if you just want to use an SSL client certificate.


### PR DESCRIPTION
Bunch of improvements to Transport docs:
* Fix hint formatting
* Show easier way to disable tls/ssl verification
* Mention that SSL is deprecated and use TSL instead
* Add section about proxy usage
