### PR TITLE
Added a test for multiple message parts.

### DIFF
--- a/tests/test_wsdl_messages_document.py
+++ b/tests/test_wsdl_messages_document.py
@@ -332,6 +332,78 @@ def test_serialize():
     assert_nodes_equal(expected, serialized.content)
 
 
+def test_serialize_multiple_parts():
+    wsdl_content = StringIO("""
+    <definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+                 xmlns:tns="http://tests.python-zeep.org/tns"
+                 xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                 targetNamespace="http://tests.python-zeep.org/tns">
+      <types>
+        <xsd:schema targetNamespace="http://tests.python-zeep.org/tns"
+                    elementFormDefault="qualified">
+          <xsd:element name="Request">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="arg1" type="xsd:string"/>
+                <xsd:element name="arg2" type="xsd:string"/>
+              </xsd:sequence>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:schema>
+      </types>
+
+      <message name="Input">
+        <part name="request1" element="tns:Request"/>
+        <part name="request2" element="tns:Request"/>
+      </message>
+
+      <portType name="TestPortType">
+        <operation name="TestOperation">
+          <input message="Input"/>
+        </operation>
+      </portType>
+
+      <binding name="TestBinding" type="tns:TestPortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="TestOperation">
+          <soap:operation soapAction=""/>
+          <input>
+            <soap:body use="literal"/>
+          </input>
+        </operation>
+      </binding>
+    </definitions>
+    """.strip())
+
+    root = wsdl.Document(wsdl_content, None)
+
+    binding = root.bindings['{http://tests.python-zeep.org/tns}TestBinding']
+    operation = binding.get('TestOperation')
+
+    serialized = operation.input.serialize(
+        request1={'arg1': 'ah1', 'arg2': 'ah2'},
+        request2={'arg1': 'ah1', 'arg2': 'ah2'}
+    )
+    expected = """
+        <?xml version="1.0"?>
+        <soap-env:Envelope
+            xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
+          <soap-env:Body>
+            <ns0:Request xmlns:ns0="http://tests.python-zeep.org/tns">
+            <ns0:arg1>ah1</ns0:arg1>
+            <ns0:arg2>ah2</ns0:arg2>
+            </ns0:Request>
+            <ns1:Request xmlns:ns1="http://tests.python-zeep.org/tns">
+            <ns1:arg1>ah1</ns1:arg1>
+            <ns1:arg2>ah2</ns1:arg2>
+            </ns1:Request>
+          </soap-env:Body>
+        </soap-env:Envelope>
+    """
+    assert_nodes_equal(expected, serialized.content)
+
+
 def test_serialize_with_header():
     wsdl_content = StringIO("""
     <definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
@@ -392,8 +464,6 @@ def test_serialize_with_header():
     AuthHeader = root.types.get_element('{http://tests.python-zeep.org/tns}Authentication')
     auth_header = AuthHeader(username='mvantellingen')
 
-    serialized = operation.input.serialize(
-        arg1='ah1', arg2='ah2', _soapheaders=[auth_header])
     serialized = operation.input.serialize(
         arg1='ah1', arg2='ah2', _soapheaders=[auth_header])
     expected = """


### PR DESCRIPTION
This pull request consists only of a test which will currently fail. I have added a WSDL file which has two `wsdl:part`s as part of a `wsdl:message`. 

It seems to fail due to
https://github.com/mvantellingen/python-zeep/blob/713c779db7699b3c13fc9b1948eb3c6cfe32d828/src/zeep/wsdl/messages/soap.py#L422-L439
which results in double wrapping of the soap message.

I am not sure what to fix there though, if I remove the wrapping it fails somewhere else :)