### PR TITLE
Fixed Chameleon schema support and added support for an edgecase with unqualified elements.

### DIFF
--- a/src/zeep/wsdl/parse.py
+++ b/src/zeep/wsdl/parse.py
@@ -39,8 +39,8 @@ def parse_abstract_message(wsdl, xmlelement):
 
     for part in xmlelement.findall('wsdl:part', namespaces=NSMAP):
         part_name = part.get('name')
-        part_element = qname_attr(part, 'element', tns)
-        part_type = qname_attr(part, 'type', tns)
+        part_element = qname_attr(part, 'element')
+        part_type = qname_attr(part, 'type')
 
         try:
             if part_element is not None:

--- a/src/zeep/wsdl/wsdl.py
+++ b/src/zeep/wsdl/wsdl.py
@@ -310,19 +310,10 @@ class Definition(object):
             },
         ]
 
-        # Check if there is a targetNameSpace on the document. Schema's are not
-        # required to have the targetNamespace attribute set, although it is
-        # good practice. When the attribute is not set the schemas is called a
-        # chameleon schema. In that case it should inherit the targetNamespace
-        # of the enclosing schema. Although it is unclear if it should just
-        # inherit the attribute from the root document it does solve some bugs.
-        # See https://github.com/mvantellingen/python-zeep/issues/879
-        target_namespace = doc.get('targetNamespace')
-
         # Find xsd:schema elements (wsdl:types/xsd:schema)
         schema_nodes = findall_multiple_ns(
             doc, 'wsdl:types/xsd:schema', namespace_sets)
-        self.types.add_documents(schema_nodes, self.location, target_namespace)
+        self.types.add_documents(schema_nodes, self.location)
 
     def parse_messages(self, doc):
         """

--- a/src/zeep/xsd/schema.py
+++ b/src/zeep/xsd/schema.py
@@ -39,8 +39,7 @@ class Schema(object):
             nodes = [node] if node is not None else []
         else:
             nodes = node
-        tns = node.get('targetNameSpace') if node is not None else None
-        self.add_documents(nodes, location, target_namespace=tns)
+        self.add_documents(nodes, location)
 
     def __repr__(self):
         main_doc = self.root_document
@@ -102,7 +101,7 @@ class Schema(object):
                     yield type_
                     seen.add(type_.qname)
 
-    def add_documents(self, schema_nodes, location, target_namespace=None):
+    def add_documents(self, schema_nodes, location):
         """
 
         :type schema_nodes: List[lxml.etree._Element]
@@ -112,8 +111,7 @@ class Schema(object):
         """
         resolve_queue = []
         for node in schema_nodes:
-            document = self.create_new_document(
-                node, location, target_namespace=target_namespace)
+            document = self.create_new_document(node, location)
             resolve_queue.append(document)
 
         for document in resolve_queue:
@@ -212,7 +210,6 @@ class Schema(object):
             namespace = target_namespace
         if base_url is None:
             base_url = url
-
         schema = SchemaDocument(namespace, url, base_url)
         self.documents.add(schema)
         schema.load(self, node)
@@ -389,6 +386,7 @@ class SchemaDocument(object):
         self._location = location
         self._target_namespace = namespace
         self._is_internal = False
+        self._has_empty_import = False
 
         # Containers for specific types
         self._attribute_groups = {}


### PR DESCRIPTION
This partially reverts the recently introduced support for chameleon
schemas in the sense that it doesn't consider the targetNamespace of the
WSDL as default namespace for the schema. Sadly it is valid (while ugly
and not widely used) to have schemas with no namespace.

Secondly this commits allows refering to those unqualified elements if
an explicit empty <import/> (sic) is found. This seems to be mostly in
line with https://www.w3.org/TR/2012/REC-xmlschema11-1-20120405/#src-resolve
(if I read it correctly).