### PR TITLE
Annotate regular expression as an r'string'

### DIFF
--- a/src/zeep/xsd/visitor.py
+++ b/src/zeep/xsd/visitor.py
@@ -427,7 +427,7 @@ class SchemaVisitor(object):
         # Check of wsdl:arayType
         array_type = node.get('{http://schemas.xmlsoap.org/wsdl/}arrayType')
         if array_type:
-            match = re.match('([^\[]+)', array_type)
+            match = re.match(r'([^\[]+)', array_type)
             if match:
                 array_type = match.groups()[0]
                 qname = as_qname(array_type, node.nsmap)


### PR DESCRIPTION
@mvantellingen This PR annotates a string containing `\[` as an `r'string'`. This prevents an invalid escape sequence warning on newer versions of Python 3:
```
DeprecationWarning: invalid escape sequence \[
    match = re.match('([^\[]+)', array_type)
```