### PR TITLE
[FIX] avoid error when the WSDL has a non binding port

### DIFF
--- a/src/zeep/wsdl/definitions.py
+++ b/src/zeep/wsdl/definitions.py
@@ -121,7 +121,11 @@ class Binding(object):
         self._operations = {}
 
     def resolve(self, definitions):
-        self.port_type = definitions.get('port_types', self.port_name.text)
+        try:
+            self.port_type = definitions.get('port_types', self.port_name.text)
+        except IndexError:
+            warnings.warn('The port_name %s has no bindings, for now we are going to ignore it', self.port_name.text)
+            return
 
         for name, operation in list(self._operations.items()):
             try:


### PR DESCRIPTION
This error can be replicated with this gist
https://gist.github.com/umiphos/543e92eef8c26aad44262bd55ba73baa
And this URL
https://e-factura.sunat.gob.pe/ol-ti-itcpfegem/billService?wsdl

You just make a new Client(URL) and you get the error from before.

Now, as you can see, that WSDL has a definition without bindings, that
makes an index error when zeep tries to get the services and bindings.
To fix that we apply this patch, in case of not bindings, we should just
warn about it and continue with the rest of the document.