### PR TITLE
Add testcase for a cylic xsd import error

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,14 @@
+3.3.1 (2019-03-05)
+------------------
+ - Fix handling recursive xsd imports when the url's are enforced from http to
+   https.
+
+
 3.3.0 (2019-02-21)
 ------------------
  - Extend the force_https flag to also force loading xsd files from https when
    a http url is encountered from a https domain
+
 
 3.2.0 (2018-12-17)
 ------------------

--- a/src/zeep/xsd/visitor.py
+++ b/src/zeep/xsd/visitor.py
@@ -185,6 +185,8 @@ class SchemaVisitor(object):
         if not namespace and not location:
             self.document._has_empty_import = True
 
+        location = normalize_location(self.schema.settings, location, self.document._location)
+
         # Check if the schema is already imported before based on the
         # namespace. Schema's without namespace are registered as 'None'
         document = self.schema.documents.get_by_namespace_and_location(namespace, location)
@@ -207,7 +209,6 @@ class SchemaVisitor(object):
             return
 
         # Load the XML
-        location = normalize_location(self.schema.settings, location, self.document._location)
         schema_node = load_external(
             location,
             transport=self.schema._transport,


### PR DESCRIPTION
This probably happens due to the http -> https enforcing which breaks
the import detection