### PR TITLE
fix(xop): respect RFC2392 when mapping href to cid

### DIFF
--- a/src/zeep/wsdl/messages/xop.py
+++ b/src/zeep/wsdl/messages/xop.py
@@ -1,4 +1,5 @@
 import base64
+from six.moves.urllib.parse import unquote
 
 
 def process_xop(document, message_pack):
@@ -12,7 +13,8 @@ def process_xop(document, message_pack):
     for xop_node in xop_nodes:
         href = xop_node.get("href")
         if href.startswith("cid:"):
-            href = "<%s>" % href[4:]
+            # URL can be encoded. RFC2392
+            href = "<%s>" % unquote(href[4:])
 
         value = message_pack.get_by_content_id(href)
         if not value:


### PR DESCRIPTION
[RFC link]( https://tools.ietf.org/html/rfc2392)

>  A "cid" URL is converted to the corresponding Content-ID message
   header [MIME] by removing the "cid:" prefix, converting the % encoded
   character to their equivalent US-ASCII characters, and enclosing the
   remaining parts with an angle bracket pair, "<" and ">"

