### PR TITLE
WSSE: Don't create an empty timestamp node in the Header just so we can sign it!

### DIFF
--- a/src/zeep/wsse/signature.py
+++ b/src/zeep/wsse/signature.py
@@ -204,13 +204,14 @@ def _signature_prepare(envelope, key):
     # Insert the Signature node in the wsse:Security header.
     security = get_security_header(envelope)
     security.insert(0, signature)
-    security.append(etree.Element(QName(ns.WSU, "Timestamp")))
 
     # Perform the actual signing.
     ctx = xmlsec.SignatureContext()
     ctx.key = key
     _sign_node(ctx, signature, envelope.find(QName(soap_env, "Body")))
-    _sign_node(ctx, signature, security.find(QName(ns.WSU, "Timestamp")))
+    timestamp = security.find(QName(ns.WSU, "Timestamp"))
+    if timestamp != None:
+        _sign_node(ctx, signature, timestamp)
     ctx.sign(signature)
 
     # Place the X509 data inside a WSSE SecurityTokenReference within

--- a/tests/test_wsse_signature.py
+++ b/tests/test_wsse_signature.py
@@ -3,7 +3,7 @@ import sys
 
 import pytest
 from lxml.etree import QName
-
+from lxml import etree
 from tests.utils import load_xml
 from zeep import ns, wsse
 from zeep.exceptions import SignatureVerificationFailed
@@ -30,24 +30,28 @@ skip_if_no_xmlsec = pytest.mark.skipif(
 def test_sign_timestamp_if_present():
     envelope = load_xml(
         """
-        <soapenv:Envelope
-            xmlns:tns="http://tests.python-zeep.org/"
-            xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-            xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+        <soap-env:Envelope
+            xmlns:ns0="http://example.com/stockquote.xsd"
             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
-            xmlns:wsu="http://schemas.xmlsoap.org/ws/2003/06/utility">
-          <soapenv:Header>
-            <wsu:Timestamp>
-              <wsu:Created>2018-11-18T15:44:27Z</wsu:Created>
-              <wsu:Expires>2018-11-18T15:54:27Z</wsu:Expires>
-            </wsu:Timestamp>
-          </soapenv:Header>
-          <soapenv:Body>
-            <tns:Function>
-              <tns:Argument>OK</tns:Argument>
-            </tns:Function>
-          </soapenv:Body>
-        </soapenv:Envelope>
+            xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"
+            xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+            xmlns:wsu="http://schemas.xmlsoap.org/ws/2003/06/utility"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <soap-env:Header xmlns:ns0="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+            <ns0:Security>
+              <wsu:Timestamp xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+                    <wsu:Created>2018-11-18T15:44:27Z</wsu:Created>
+                    <wsu:Expires>2018-11-18T15:54:27Z</wsu:Expires>
+              </wsu:Timestamp>
+            </ns0:Security>
+          </soap-env:Header>
+          <soap-env:Body>
+            <ns0:TradePriceRequest>
+              <tickerSymbol>foobar</tickerSymbol>
+              <ns0:country/>
+            </ns0:TradePriceRequest>
+          </soap-env:Body>
+        </soap-env:Envelope>
     """
     )
 

--- a/tests/test_wsse_signature.py
+++ b/tests/test_wsse_signature.py
@@ -27,6 +27,34 @@ skip_if_no_xmlsec = pytest.mark.skipif(
 
 
 @skip_if_no_xmlsec
+def test_sign_timestamp_if_present():
+    envelope = load_xml(
+        """
+        <soapenv:Envelope
+            xmlns:tns="http://tests.python-zeep.org/"
+            xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+            xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+            xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+            xmlns:wsu="http://schemas.xmlsoap.org/ws/2003/06/utility">
+          <soapenv:Header>
+            <wsu:Timestamp>
+              <wsu:Created>2018-11-18T15:44:27Z</wsu:Created>
+              <wsu:Expires>2018-11-18T15:54:27Z</wsu:Expires>
+            </wsu:Timestamp>
+          </soapenv:Header>
+          <soapenv:Body>
+            <tns:Function>
+              <tns:Argument>OK</tns:Argument>
+            </tns:Function>
+          </soapenv:Body>
+        </soapenv:Envelope>
+    """
+    )
+
+    signature.sign_envelope(envelope, KEY_FILE, KEY_FILE)
+    signature.verify_envelope(envelope, KEY_FILE)
+
+@skip_if_no_xmlsec
 def test_sign():
     envelope = load_xml(
         """


### PR DESCRIPTION
Resolves an issue I had connecting to a service that doesn't require the Timestamp element.