### PR TITLE
Fix #953. client.wsse may be a list

### DIFF
--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -181,8 +181,12 @@ class SoapBinding(Binding):
             if process_xop(doc, message_pack):
                 message_pack = None
 
-        if client.wsse:
-            client.wsse.verify(doc)
+        security_tokens = client.wsse
+        if security_tokens:
+            if not isinstance(security_tokens, (list, tuple)):
+                security_tokens = [security_tokens]
+            for token in security_tokens:
+                token.verify(doc)
 
         doc, http_headers = plugins.apply_ingress(
             client, doc, response.headers, operation


### PR DESCRIPTION
A first pull request, but I'm not sure if signature verification handling is correctly implemented. The response security tokens may not be the same as the request tokens. I found that wsse.username.UsernameToken ignores verification, still have to check other ones.