### PR TITLE
Fix RuntimeError: 'NoneType' object has no attribute 'clone'

### DIFF
--- a/src/zeep/wsdl/messages/soap.py
+++ b/src/zeep/wsdl/messages/soap.py
@@ -439,8 +439,11 @@ class DocumentMessage(SoapMessage):
         else:
             sub_elements = []
             for part_name, part in parts.items():
-                element = part.element.clone()
-                element.attr_name = part_name or element.name
+                if part.element:
+                    element = part.element.clone()
+                    element.attr_name = part_name or element.name
+                else:
+                    element = xsd.Element(part_name, part.type)
                 sub_elements.append(element)
 
         if len(sub_elements) > 1:


### PR DESCRIPTION
Fix RuntimeError: 'NoneType' object has no attribute 'clone' that happens with wsdl of customer (redacted, due to NDA issues). This fixes #898
