### PR TITLE
Skip tests if xmlsec is not installed

### DIFF
--- a/tests/test_wsse_signature.py
+++ b/tests/test_wsse_signature.py
@@ -187,7 +187,7 @@ def test_signature():
     plugin.verify(envelope)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+@skip_if_no_xmlsec
 @pytest.mark.parametrize("digest_method,expected_digest_href", DIGEST_METHODS_TESTDATA)
 @pytest.mark.parametrize(
     "signature_method,expected_signature_href", SIGNATURE_METHODS_TESTDATA


### PR DESCRIPTION
This fixes errors in the testsuite ala:
```
_____________________________________________________ test_signature_binary[RSA_SHA256-http://www.w3.org/2001/04/xmldsig-more#rsa-sha256-SHA256-http://www.w3.org/2001/04/xmlenc#sha256] _____________________________________________________

digest_method = 'SHA256', signature_method = 'RSA_SHA256', expected_digest_href = 'http://www.w3.org/2001/04/xmlenc#sha256', expected_signature_href = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'

    @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
    @pytest.mark.parametrize("digest_method,expected_digest_href", DIGEST_METHODS_TESTDATA)
    @pytest.mark.parametrize(
        "signature_method,expected_signature_href", SIGNATURE_METHODS_TESTDATA
    )
    def test_signature_binary(
        digest_method, signature_method, expected_digest_href, expected_signature_href
    ):
        envelope = load_xml(
            """
            <soapenv:Envelope
                xmlns:tns="http://tests.python-zeep.org/"
                xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
                xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
                xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
              <soapenv:Header></soapenv:Header>
              <soapenv:Body>
                <tns:Function>
                  <tns:Argument>OK</tns:Argument>
                </tns:Function>
              </soapenv:Body>
            </soapenv:Envelope>
        """
        )
    
        plugin = wsse.BinarySignature(
            KEY_FILE_PW,
            KEY_FILE_PW,
            "geheim",
>           signature_method=getattr(xmlsec_installed.Transform, signature_method),
            digest_method=getattr(xmlsec_installed.Transform, digest_method),
        )
E       AttributeError: 'NoneType' object has no attribute 'Transform'
```