### PR TITLE
Drop support for python 3.3 & 3.4

### DIFF
--- a/.azure-pipelines/job.yml
+++ b/.azure-pipelines/job.yml
@@ -13,9 +13,6 @@ jobs:
       Python 2.7:
         python.version: "2.7"
         TOXENV: "py27-${{ parameters.os }}"
-      Python 3.4:
-        python.version: "3.4"
-        TOXENV: "py34-${{ parameters.os }}"
       Python 3.5:
         python.version: "3.5"
         TOXENV: "py35-${{ parameters.os }}"

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Zeep: Python SOAP client
 A fast and modern Python SOAP client
 
 Highlights:
- * Compatible with Python 2.7, 3.3, 3.4, 3.5, 3.6, 3.7 and PyPy
+ * Compatible with Python 2.7, 3.5, 3.6, 3.7 and PyPy
  * Build on top of lxml and requests
  * Support for Soap 1.1, Soap 1.2 and HTTP bindings
  * Support for WS-Addressing headers

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ Zeep: Python SOAP client
 A fast and modern Python SOAP client
 
 Highlights:
- * Compatible with Python 2.7, 3.3, 3.4, 3.5, 3.6, 3.7 and PyPy
+ * Compatible with Python 2.7, 3.5, 3.6, 3.7 and PyPy
  * Build on top of lxml and requests
  * Support for Soap 1.1, Soap 1.2 and HTTP bindings
  * Support for WS-Addressing headers

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37}-{mac,linux,windows},pypy
+envlist = py{27,35,36,37}-{mac,linux,windows},pypy
 
 
 [testenv]


### PR DESCRIPTION
Since both Python 3.4 & 3.3 are EOL and new lxml versions do not support 3.4 anymore, drop it from lxml.