### PR TITLE
Remove AnySimpleType.pythonvalue() method override

### DIFF
--- a/src/zeep/xsd/types/simple.py
+++ b/src/zeep/xsd/types/simple.py
@@ -72,11 +72,6 @@ class AnySimpleType(AnyType):
             logger.exception("Error during xml -> python translation")
             return None
 
-    def pythonvalue(self, xmlvalue):
-        raise NotImplementedError(
-            "%s.pytonvalue() not implemented" % self.__class__.__name__
-        )
-
     def render(self, parent, value, xsd_type=None, render_path=None):
         if value is Nil:
             parent.set(xsi_ns("nil"), "true")

--- a/tests/test_xsd_types.py
+++ b/tests/test_xsd_types.py
@@ -43,8 +43,7 @@ def test_simpletype_parse():
 def test_simpletype_pythonvalue():
     item = types.AnySimpleType()
 
-    with pytest.raises(NotImplementedError):
-        item.pythonvalue(None)
+    assert item.pythonvalue("foobar") == "foobar"
 
 
 def test_simpletype_call_wrong_arg_count():

--- a/tests/test_xsd_types.py
+++ b/tests/test_xsd_types.py
@@ -1,5 +1,8 @@
+import isodate
 import pytest
 import six
+from datetime import datetime, time
+from decimal import Decimal
 from lxml import etree
 
 from zeep.xsd import types
@@ -40,10 +43,67 @@ def test_simpletype_parse():
     assert item.parse_xmlelement(node) is None
 
 
-def test_simpletype_pythonvalue():
+def test_simpletype_pythonvalue_string():
     item = types.AnySimpleType()
+    value = "foobar"
 
-    assert item.pythonvalue("foobar") == "foobar"
+    assert item.pythonvalue(value) == value
+
+
+def test_simpletype_pythonvalue_bool():
+    item = types.AnySimpleType()
+    value = False
+
+    assert item.pythonvalue(value) == value
+
+
+def test_simpletype_pythonvalue_decimal():
+    item = types.AnySimpleType()
+    value = Decimal("3.14")
+
+    assert item.pythonvalue(value) == value
+
+
+def test_simpletype_pythonvalue_float():
+    item = types.AnySimpleType()
+    value = 3.14
+
+    assert item.pythonvalue(value) == value
+
+
+def test_simpletype_pythonvalue_float():
+    item = types.AnySimpleType()
+    value = 3.14
+
+    assert item.pythonvalue(value) == value
+
+
+def test_simpletype_pythonvalue_duration():
+    item = types.AnySimpleType()
+    value = isodate.parse_duration("P1Y2M3DT4H5M6S")
+
+    assert item.pythonvalue(value) == value
+
+
+def test_simpletype_pythonvalue_datetime():
+    item = types.AnySimpleType()
+    value = datetime.now()
+
+    assert item.pythonvalue(value) == value
+
+
+def test_simpletype_pythonvalue_time():
+    item = types.AnySimpleType()
+    value = datetime.now().time()
+
+    assert item.pythonvalue(value) == value
+
+
+def test_simpletype_pythonvalue_date():
+    item = types.AnySimpleType()
+    value = datetime.now().date()
+
+    assert item.pythonvalue(value) == value
 
 
 def test_simpletype_call_wrong_arg_count():

--- a/tests/test_xsd_types.py
+++ b/tests/test_xsd_types.py
@@ -71,13 +71,6 @@ def test_simpletype_pythonvalue_float():
     assert item.pythonvalue(value) == value
 
 
-def test_simpletype_pythonvalue_float():
-    item = types.AnySimpleType()
-    value = 3.14
-
-    assert item.pythonvalue(value) == value
-
-
 def test_simpletype_pythonvalue_duration():
     item = types.AnySimpleType()
     value = isodate.parse_duration("P1Y2M3DT4H5M6S")


### PR DESCRIPTION
Fix #418. This is similar to the fix for #644.