### PR TITLE
added support for dates that are compliant with RFC3339

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/home/ahmad/github.com/10ten-me/python-zeep/env/bin/python3"
+}

--- a/src/zeep/xsd/types/builtins.py
+++ b/src/zeep/xsd/types/builtins.py
@@ -151,7 +151,7 @@ class DateTime(BuiltinType, AnySimpleType):
         # lazy hack ;-)
         if len(value) == 10:
             value += "T00:00:00"
-        elif len(value) == 19 and value.endswith(' 00:00:00'):
+        elif (len(value) == 19 or len(value) == 26) and value[10] == " ":
             value = "T".join(value.split(" "))
         return isodate.parse_datetime(value)
 

--- a/src/zeep/xsd/types/builtins.py
+++ b/src/zeep/xsd/types/builtins.py
@@ -151,6 +151,8 @@ class DateTime(BuiltinType, AnySimpleType):
         # lazy hack ;-)
         if len(value) == 10:
             value += "T00:00:00"
+        elif len(value) == 19 and value.endswith(' 00:00:00'):
+            value = "T".join(value.split(" "))
         return isodate.parse_datetime(value)
 
 

--- a/tests/test_xsd_builtins.py
+++ b/tests/test_xsd_builtins.py
@@ -135,6 +135,9 @@ class TestDateTime:
         value = datetime.datetime(2016, 3, 4, 21, 14, 42)
         assert instance.pythonvalue("2016-03-04T21:14:42") == value
 
+        value = datetime.datetime(2016, 3, 4, 0, 0, 0)
+        assert instance.pythonvalue("2016-03-04 00:00:00") == value
+
         value = datetime.datetime(2016, 3, 4, 21, 14, 42, 123456)
         assert instance.pythonvalue("2016-03-04T21:14:42.123456") == value
 

--- a/tests/test_xsd_builtins.py
+++ b/tests/test_xsd_builtins.py
@@ -139,6 +139,9 @@ class TestDateTime:
         assert instance.pythonvalue("2016-03-04 00:00:00") == value
 
         value = datetime.datetime(2016, 3, 4, 21, 14, 42, 123456)
+        assert instance.pythonvalue("2016-03-04 21:14:42.123456") == value
+
+        value = datetime.datetime(2016, 3, 4, 21, 14, 42, 123456)
         assert instance.pythonvalue("2016-03-04T21:14:42.123456") == value
 
         value = datetime.datetime(2016, 3, 4, 0, 0, 0)


### PR DESCRIPTION
Many old API use this format for dates:
```
%Y-%m-%d %H:%M:%S
2019-11-04 00:00:00
```
This raise exception in zeep because the expected ISO format must include `T` instead of space:
```
%Y-%m-%dT%H:%M:%S
2019-11-04T00:00:00
```
this addition will automatically detect the case and add a `T` instead of space.

Note the first date format is compliant with `RFC3339` standards and is used by many old API providers
https://stackoverflow.com/a/34006233