### PR TITLE
test python 3.8

### DIFF
--- a/.azure-pipelines/job.yml
+++ b/.azure-pipelines/job.yml
@@ -22,6 +22,9 @@ jobs:
       Python 3.7:
         python.version: "3.7"
         TOXENV: "py37-${{ parameters.os }}"
+      Python 3.8:
+        python.version: "3.8"
+        TOXENV: "py38-${{ parameters.os }}"
   steps:
   - template: steps.yml
     parameters:

--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 ========================
-Zeep: Python SOAP client 
+Zeep: Python SOAP client
 ========================
 
 A fast and modern Python SOAP client
 
 Highlights:
- * Compatible with Python 2.7, 3.5, 3.6, 3.7 and PyPy
+ * Compatible with Python 2.7, 3.5, 3.6, 3.7, 3.8 and PyPy
  * Build on top of lxml and requests
  * Support for Soap 1.1, Soap 1.2 and HTTP bindings
  * Support for WS-Addressing headers
@@ -26,11 +26,11 @@ Status
 
 .. image:: https://readthedocs.org/projects/python-zeep/badge/?version=latest
     :target: https://readthedocs.org/projects/python-zeep/
-   
+
 .. image:: https://dev.azure.com/mvantellingen/zeep/_apis/build/status/python-zeep?branchName=master
     :target: https://dev.azure.com/mvantellingen/zeep/_build?definitionId=1
 
-.. image:: http://codecov.io/github/mvantellingen/python-zeep/coverage.svg?branch=master 
+.. image:: http://codecov.io/github/mvantellingen/python-zeep/coverage.svg?branch=master
     :target: http://codecov.io/github/mvantellingen/python-zeep?branch=master
 
 .. image:: https://img.shields.io/pypi/v/zeep.svg
@@ -68,7 +68,7 @@ information.
 Support
 =======
 
-If you want to report a bug then please first read 
+If you want to report a bug then please first read
 http://docs.python-zeep.org/en/master/reporting_bugs.html
 
-Please only report bugs and not support requests to the GitHub issue tracker. 
+Please only report bugs and not support requests to the GitHub issue tracker.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ Zeep: Python SOAP client
 A fast and modern Python SOAP client
 
 Highlights:
- * Compatible with Python 2.7, 3.5, 3.6, 3.7 and PyPy
+ * Compatible with Python 2.7, 3.5, 3.6, 3.7, 3.8 and PyPy
  * Build on top of lxml and requests
  * Support for Soap 1.1, Soap 1.2 and HTTP bindings
  * Support for WS-Addressing headers

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37}-{mac,linux,windows},pypy
+envlist = py{27,35,36,37,38}-{mac,linux,windows},pypy
 
 
 [testenv]
@@ -10,12 +10,12 @@ platform =
 extras =
     test
     {mac,linux}: xmlsec
-    py{35,36,37}: async
-    py{35,36,37}: tornado
+    py{35,36,37,38}: async
+    py{35,36,37,38}: tornado
 deps =
-    py{35,36,37}: aioresponses==0.5.0
-    py{35,36,37}: aiohttp==3.4.4
-    py{35,36,37}: pytest-asyncio==0.9.0
+    py{35,36,37,38}: aioresponses==0.5.0
+    py{35,36,37,38}: aiohttp==3.4.4
+    py{35,36,37,38}: pytest-asyncio==0.9.0
 commands = coverage run --parallel -m pytest {posargs}
 
 


### PR DESCRIPTION
Shows that Zeep works with python 3.8.

Optional requirement tornado 4 does not support python 3.8 (https://github.com/mvantellingen/python-zeep/issues/990)