### PR TITLE
allow bytes-like object as password argument to UsernameToken

### DIFF
--- a/src/zeep/wsse/username.py
+++ b/src/zeep/wsse/username.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import os
+import six
 
 from zeep import ns
 from zeep.wsse import utils
@@ -97,11 +98,16 @@ class UsernameToken(object):
             nonce = os.urandom(16)
         timestamp = utils.get_timestamp(self.created)
 
+        if isinstance(self.password, six.string_types):
+            password = self.password.encode("utf-8")
+        else:
+            password = self.password
+
         # digest = Base64 ( SHA-1 ( nonce + created + password ) )
         if not self.password_digest:
             digest = base64.b64encode(
                 hashlib.sha1(
-                    nonce + timestamp.encode("utf-8") + self.password.encode("utf-8")
+                    nonce + timestamp.encode("utf-8") + password
                 ).digest()
             ).decode("ascii")
         else:


### PR DESCRIPTION
This PR allows `UsernameToken` to take a bytes-like object as password argument which I believe is in line with the spec.

https://www.oasis-open.org/committees/download.php/13392/wss-v1.1-spec-pr-UsernameTokenProfile-01.htm

The spec says of `PasswordText`:

```The actual password for the username, the password hash, or derived password or S/KEY.```

I have a use-case that requires the password be SHA-1 before being concatenated, e.g.,

```# digest = Base64 ( SHA-1 ( nonce + created + SHA-1 ( password ) ) )```

The current implementation throws an `AttributeError` when calling `self.password.encode('utf-8')`. This PR checks to see whether `.encode` should be called on `self.password`.
