### PR TITLE
Fixes #928 - AttributeError: _tls when debugging in PyCharm

### DIFF
--- a/src/zeep/settings.py
+++ b/src/zeep/settings.py
@@ -74,7 +74,8 @@ class Settings(object):
             else:
                 setattr(self._tls, key, value)
 
-    def __getattribute__(self, key):
+    def __getattr__(self, key):
         if key != "_tls" and hasattr(self._tls, key):
             return getattr(self._tls, key)
-        return super(Settings, self).__getattribute__(key)
+
+        raise AttributeError(key)


### PR DESCRIPTION
This exception was being raised because of some introspection that PyCharm was doing as part of starting the debugger.  Easiest way around this is to implement __getattr__ instead of __getattribute__, which functions similarly, but is a little easier to manage in cases like this.

References:
https://stackoverflow.com/a/3278104/1697679
https://stackoverflow.com/a/38788326/1697679