### PR TITLE
Change NotImplemented to NotImplementedError

### DIFF
--- a/src/zeep/cache.py
+++ b/src/zeep/cache.py
@@ -23,10 +23,10 @@ logger = logging.getLogger(__name__)
 
 class Base(object):
     def add(self, url, content):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def get(self, url):
-        raise NotImplemented()
+        raise NotImplementedError()
 
 
 class InMemoryCache(Base):


### PR DESCRIPTION
As mentioned at [NotImplementedError](https://docs.python.org/3/library/exceptions.html#NotImplementedError) & [NotImplemented](https://docs.python.org/3/library/constants.html#NotImplemented),`NotImplemented` is not exception class and can not be raised. `NotImplementedError` should be raised instead of `NotImplemented`. This pull request will fix this bug.