### PR TITLE
Accept strings for xsd base64Binary

### DIFF
--- a/src/zeep/xsd/types/builtins.py
+++ b/src/zeep/xsd/types/builtins.py
@@ -339,6 +339,8 @@ class Base64Binary(BuiltinType, AnySimpleType):
 
     @check_no_collection
     def xmlvalue(self, value):
+        if isinstance(value, six.string_types):
+            return value
         return base64.b64encode(value)
 
     def pythonvalue(self, value):

--- a/tests/test_xsd_builtins.py
+++ b/tests/test_xsd_builtins.py
@@ -222,8 +222,8 @@ class TestgYearMonth:
 class TestgYear:
     def test_xmlvalue(self):
         instance = builtins.gYear()
-        instance.xmlvalue((2001, None)) == "2001"
-        instance.xmlvalue((2001, pytz.utc)) == "2001Z"
+        assert instance.xmlvalue((2001, None)) == "2001"
+        assert instance.xmlvalue((2001, pytz.utc)) == "2001Z"
 
     def test_pythonvalue(self):
         instance = builtins.gYear()

--- a/tests/test_xsd_builtins.py
+++ b/tests/test_xsd_builtins.py
@@ -313,6 +313,10 @@ class TestBase64Binary:
     def test_xmlvalue(self):
         instance = builtins.Base64Binary()
         assert instance.xmlvalue(b"hoi") == b"aG9p"
+        assert (
+            instance.xmlvalue("aG9p")
+            == "aG9p"
+        )
 
     def test_pythonvalue(self):
         instance = builtins.Base64Binary()


### PR DESCRIPTION
According to [issue](https://github.com/mvantellingen/python-zeep/issues/395) it would be nice if a value for an element of type xsd:base64Binary could be passed already encoded as string. Since `accepted_types = six.string_types` in `Base64Binary` I suggest the same solution as for the mentioned Datetime issue (passing datetime as string).
By the way I fixed to missing assert statements.