### PR TITLE
Fixes #953 - AttributeError: 'list' object has no attribute 'verify' when you pass in list wsse

### DIFF
--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -182,7 +182,11 @@ class SoapBinding(Binding):
                 message_pack = None
 
         if client.wsse:
-            client.wsse.verify(doc)
+            if isinstance(client.wsse, list):
+                for wsse in client.wsse:
+                    wsse.verify(doc)
+            else:
+                client.wsse.verify(doc)
 
         doc, http_headers = plugins.apply_ingress(
             client, doc, response.headers, operation


### PR DESCRIPTION
A simple bugfix for #953  'AttributeError: 'list' object has no attribute 'verify'' that occurs when the user passes in a list with UsernameToken() and Signature() to the wsse argument in the Client class.
