### PR TITLE
Avoid convert duration by isodate if argument is string type

### DIFF
--- a/src/zeep/xsd/types/builtins.py
+++ b/src/zeep/xsd/types/builtins.py
@@ -107,7 +107,10 @@ class Duration(BuiltinType):
 
     @check_no_collection
     def xmlvalue(self, value):
-        return isodate.duration_isoformat(value)
+        if isinstance(value, str):
+            return value
+        else:
+            return isodate.duration_isoformat(value)
 
     def pythonvalue(self, value):
         if value.startswith("PT-"):


### PR DESCRIPTION
When converting duration value to xmlvalue, if the duration value as argument is already a string type, then just return the string.
I'm working on a case that receives payload as JSON, and the duration values are string type, such as "PT1S".
If I pass those duration values to zeep, it produces "P%P".
So I made this change to xmlvalue function to avoid force converting.