### PR TITLE
Fix wsse verificatio for multiple wsse's, allow tuple for wsse

### DIFF
--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -93,7 +93,7 @@ class SoapBinding(Binding):
 
             # Apply WSSE
             if client.wsse:
-                if isinstance(client.wsse, list):
+                if isinstance(client.wsse, (list, tuple)):
                     for wsse in client.wsse:
                         envelope, http_headers = wsse.apply(envelope, http_headers)
                 else:
@@ -187,7 +187,11 @@ class SoapBinding(Binding):
                 message_pack = None
 
         if client.wsse:
-            client.wsse.verify(doc)
+            if isinstance(client.wsse, (list, tuple)):
+                for wsse in client.wsse:
+                    wsse.verify(doc)
+            else:
+                client.wsse.verify(doc)
 
         doc, http_headers = plugins.apply_ingress(
             client, doc, response.headers, operation


### PR DESCRIPTION
Wsse is applied correctly, but when using multiplse WSSE (i use both UsernameToken and SignatureZeepWsse) without a patch, it failes to verify doc.