### PR TITLE
Add ssl_context parameter in AsyncTransport

### DIFF
--- a/examples/async_client.py
+++ b/examples/async_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import ssl
 import time
 
 import zeep
@@ -17,7 +18,10 @@ def run_async():
 
     loop = asyncio.get_event_loop()
 
-    transport = AsyncTransport(loop, cache=None)
+    # Optionally, an SSLContext can be provided to customize SSL options
+    ssl_context = ssl.create_default_context()
+
+    transport = AsyncTransport(loop, cache=None, ssl_context=ssl_context)
     client = zeep.Client('http://localhost:8000/?wsdl', transport=transport)
 
     tasks = [

--- a/src/zeep/asyncio/transport.py
+++ b/src/zeep/asyncio/transport.py
@@ -37,6 +37,7 @@ class AsyncTransport(Transport):
         session=None,
         verify_ssl=True,
         proxy=None,
+        ssl_context=None
     ):
 
         self.loop = loop if loop else asyncio.get_event_loop()
@@ -47,6 +48,7 @@ class AsyncTransport(Transport):
 
         self.verify_ssl = verify_ssl
         self.proxy = proxy
+        self.ssl_context = ssl_context
         self.session = session or aiohttp.ClientSession(loop=self.loop)
         self._close_session = session is None
         self.session._default_headers[
@@ -93,6 +95,7 @@ class AsyncTransport(Transport):
                 headers=headers,
                 verify_ssl=self.verify_ssl,
                 proxy=self.proxy,
+                ssl_context=self.ssl_context
             )
             self.logger.debug(
                 "HTTP Response from %s (status: %d):\n%s",
@@ -115,6 +118,7 @@ class AsyncTransport(Transport):
                 headers=headers,
                 verify_ssl=self.verify_ssl,
                 proxy=self.proxy,
+                ssl_context=self.ssl_context
             )
 
             return await self.new_response(response)


### PR DESCRIPTION
in order to provide a custom SSLContext for client-side verification in async mode (fixes #1095).

I'm unsure how to test this as this would require aioresponses to be able to distinguish SSLContext.