### PR TITLE
Implemented zulu timestamp and hashed passwords before concatenation

### DIFF
--- a/src/zeep/wsse/username.py
+++ b/src/zeep/wsse/username.py
@@ -49,7 +49,14 @@ class UsernameToken:
         nonce=None,
         created=None,
         timestamp_token=None,
+        zulu_timestamp=None,
+        hash_password=None,
     ):
+        '''
+        Some SOAP services want zulu timestamps with Z in timestamps and
+        in password digests they may want password to be hashed before
+        adding it to nonce and created.
+        '''
         self.username = username
         self.password = password
         self.password_digest = password_digest
@@ -57,6 +64,9 @@ class UsernameToken:
         self.created = created
         self.use_digest = use_digest
         self.timestamp_token = timestamp_token
+        self.zulu_timestamp = zulu_timestamp
+        self.hash_password = hash_password
+
 
     def apply(self, envelope, headers):
         security = utils.get_security_header(envelope)
@@ -97,7 +107,7 @@ class UsernameToken:
             nonce = self.nonce.encode("utf-8")
         else:
             nonce = os.urandom(16)
-        timestamp = utils.get_timestamp(self.created)
+        timestamp = utils.get_timestamp(self.created, self.zulu_timestamp)
 
         if isinstance(self.password, six.string_types):
             password = self.password.encode("utf-8")
@@ -105,7 +115,11 @@ class UsernameToken:
             password = self.password
 
         # digest = Base64 ( SHA-1 ( nonce + created + password ) )
-        if not self.password_digest:
+        if not self.password_digest and self.hash_password:
+            digest = base64.b64encode(
+                hashlib.sha1(nonce + timestamp.encode("utf-8") + hashlib.sha1(password).digest()).digest()
+            ).decode("ascii")
+        elif not self.password_digest:
             digest = base64.b64encode(
                 hashlib.sha1(nonce + timestamp.encode("utf-8") + password).digest()
             ).decode("ascii")

--- a/src/zeep/wsse/utils.py
+++ b/src/zeep/wsse/utils.py
@@ -27,10 +27,13 @@ def get_security_header(doc):
     return security
 
 
-def get_timestamp(timestamp=None):
+def get_timestamp(timestamp=None, zulu_timestamp=None):
     timestamp = timestamp or datetime.datetime.utcnow()
     timestamp = timestamp.replace(tzinfo=pytz.utc, microsecond=0)
-    return timestamp.isoformat()
+    if zulu_timestamp:
+        return timestamp.isoformat().replace("+00:00", "Z")
+    else:
+        return timestamp.isoformat()
 
 
 def get_unique_id():


### PR DESCRIPTION
Some SOAP services want zulu timestamps with Z in timestamps and in password digests they may want password to be hashed before adding it to nonce and created.