### PR TITLE
Handle message parts with no element

### DIFF
--- a/src/zeep/wsdl/messages/soap.py
+++ b/src/zeep/wsdl/messages/soap.py
@@ -454,8 +454,14 @@ class DocumentMessage(SoapMessage):
         else:
             sub_elements = []
             for part_name, part in parts.items():
-                element = part.element.clone()
-                element.attr_name = part_name or element.name
+                if part.element is not None:
+                    element = part.element.clone()
+                    element.attr_name = part_name or element.name
+                else:
+                    element = xsd.Element(
+                        name=part_name,
+                        type_=part.type
+                    )
                 sub_elements.append(element)
 
         if len(sub_elements) > 1:


### PR DESCRIPTION
When no element is specified in a wsdl:part definition responses are not correctly handled. This PR handles this case and creates a dummy element with the appropriate type, allowing correct deserialization of responses.

Closes #1115 