### PR TITLE
MIME multipart encapsulation for sending attachments

### DIFF
--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -140,16 +140,9 @@ class Client:
         :rtype: lxml.etree._Element
 
         """
-        envelope, http_headers = service._binding._create(
+        envelope, http_headers, is_mime_multipart = service._binding._create(
             operation_name, args, kwargs, client=self
         )
-
-        if "attachments" in kwargs:
-            multipart_request, http_headers = self._create_multipart(
-                operation, envelope, http_headers, args, kwargs
-            )
-
-            return multipart_request
 
         return envelope
 

--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -143,6 +143,14 @@ class Client:
         envelope, http_headers = service._binding._create(
             operation_name, args, kwargs, client=self
         )
+
+        if "attachments" in kwargs:
+            multipart_request, http_headers = self._create_multipart(
+                operation, envelope, http_headers, args, kwargs
+            )
+
+            return multipart_request
+
         return envelope
 
     def type_factory(self, namespace):

--- a/src/zeep/wsdl/attachments.py
+++ b/src/zeep/wsdl/attachments.py
@@ -5,9 +5,29 @@ See https://www.w3.org/TR/SOAP-attachments
 """
 
 import base64
+import pathlib
+import io
+import mimetypes
+
+from typing import Union
 
 from cached_property import cached_property
 from requests.structures import CaseInsensitiveDict
+
+from requests_toolbelt.multipart.encoder import MultipartEncoder, Part
+
+
+class MessageMultipartEncoder(MultipartEncoder):
+    def _prepare_parts(self):
+        self.parts = []
+
+        for field in self._iter_fields():
+            if "Content-Disposition" in field.headers:
+                del field.headers["Content-Disposition"]
+
+            self.parts.append(Part.from_field(field, self.encoding))
+
+        self._iter_parts = iter(self.parts)
 
 
 class MessagePack:
@@ -78,3 +98,72 @@ class Attachment:
             return content.strip(b"\r\n")
         else:
             return content
+
+
+class AttachmentEncodable:
+    def __init__(
+        self,
+        name: str = None,
+        data: Union[io.IOBase, bytes] = b"",
+        content_type: str = None,
+    ):
+        """
+        data can be a stream or a bytes object.
+        """
+
+        self.data = data
+
+        # What follows are best-guess heuristics for determining name and content type.
+        if isinstance(data, (io.TextIOWrapper, io.BufferedReader)):
+            file_path = pathlib.Path(data.name)
+
+            if name is None:
+                name = file_path.name
+
+            if content_type is None:
+                content_type, encoding = mimetypes.guess_type(name)
+
+                if content_type is None:
+                    if isinstance(data, io.TextIOWrapper):
+                        content_type = "text/plain"
+                    else:
+                        content_type = "application/octet-stream"
+        else:
+            if name is None:
+                name = "attachment"
+
+        self.name = name
+        self.data = data
+        self.content_type = content_type
+
+    def to_multipart_field_def(self):
+        return (None, self.data, self.content_type, {"Content-ID": f"<{self.name}>"})
+
+    def __repr__(self):
+        return f"AttachmentEncodable(name={self.name}, data={repr(self.data)}, content_type={self.content_type}"
+
+    def __str__(self):
+        return repr(self)
+
+
+class AttachmentCollection(list):
+    def __init__(self, *args, **kwargs):
+        args = list(args)
+
+        for i, arg in enumerate(args):
+            if isinstance(arg, (io.TextIOWrapper, io.BufferedReader)):
+                args[i] = AttachmentEncodable(data=arg)
+            if isinstance(arg, tuple):
+                if len(arg) == 2:
+                    args[i] = AttachmentEncodable(name=arg[0], data=arg[1])
+                elif len(arg) == 3:
+                    args[i] = AttachmentEncodable(
+                        name=arg[0], data=arg[1], content_type=arg[2]
+                    )
+
+        super().__init__(args, **kwargs)
+
+    def to_multipart_field_defs(self):
+        return {
+            attachment.name: attachment.to_multipart_field_def() for attachment in self
+        }

--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -168,8 +168,8 @@ class SoapBinding(Binding):
         envelope_headers["Content-ID"] = f"<{root_name}>"
         envelope_field = (None, etree_to_string(envelope), "text/xml", envelope_headers)
 
-        fields = attachments.to_multipart_field_defs()
         fields[root_name] = envelope_field
+        attachments.to_multipart_field_defs(fields_dict=fields)
 
         encoder = MessageMultipartEncoder(fields, boundary=boundary, encoding=encoding)
 
@@ -177,7 +177,6 @@ class SoapBinding(Binding):
             encoder.to_string(),
             {
                 "MIME-Version": "1.0",
-                "Content-Transfer-Encoding": f"binary",
                 "Content-Type": f'multipart/related; boundary={boundary}; start="<{root_name}>"',
             },
         )

--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -1,5 +1,6 @@
 import logging
 import typing
+import uuid
 
 from lxml import etree
 from requests_toolbelt.multipart.decoder import MultipartDecoder
@@ -8,7 +9,12 @@ from zeep import ns, plugins, wsa
 from zeep.exceptions import Fault, TransportError, XMLSyntaxError
 from zeep.loader import parse_xml
 from zeep.utils import as_qname, get_media_type, qname_attr
-from zeep.wsdl.attachments import MessagePack
+from zeep.wsdl.attachments import (
+    MessagePack,
+    MessageMultipartEncoder,
+    AttachmentEncodable,
+    AttachmentCollection,
+)
 from zeep.wsdl.definitions import Binding, Operation
 from zeep.wsdl.messages import DocumentMessage, RpcMessage
 from zeep.wsdl.messages.xop import process_xop
@@ -65,6 +71,20 @@ class SoapBinding(Binding):
         Note that this generates the soap envelope without the wsse applied.
 
         """
+        attachments = kwargs.pop("attachments", None)
+        multipart_opts = None
+
+        if attachments:
+            if not isinstance(attachments, AttachmentCollection):
+                raise TypeError(
+                    "The `attachments' kwarg MUST be an AttachmentCollection"
+                )
+
+            is_mime_multipart = True
+            multipart_opts = self._pop_multipart_kwargs(kwargs)
+        else:
+            is_mime_multipart = False
+
         operation_obj = self.get(operation)
         if not operation_obj:
             raise ValueError("Operation %r not found" % operation)
@@ -99,11 +119,68 @@ class SoapBinding(Binding):
                 else:
                     envelope, http_headers = client.wsse.apply(envelope, http_headers)
 
+        if is_mime_multipart:
+            multipart_request, multipart_headers = self._create_multipart(
+                operation,
+                envelope,
+                http_headers,
+                args,
+                kwargs,
+                attachments,
+                multipart_opts,
+            )
+
+            envelope = multipart_request
+            http_headers = multipart_headers
+
         # Add extra http headers from the setings object
         if client.settings.extra_http_headers:
             http_headers.update(client.settings.extra_http_headers)
 
-        return envelope, http_headers
+        return envelope, http_headers, is_mime_multipart
+
+    def _random_boundary(self):
+        return f"Multipart-{uuid.uuid4()}"
+
+    def _pop_multipart_kwargs(self, kwargs):
+        return {
+            "root_id": kwargs.pop("root_id", "root"),
+            "boundary": kwargs.pop("boundary", self._random_boundary()),
+            "encoding": kwargs.pop("encoding", "utf-8"),
+        }
+
+    def _create_multipart(
+        self,
+        operation,
+        envelope,
+        envelope_headers,
+        args,
+        kwargs,
+        attachments,
+        multipart_opts,
+    ):
+        root_name = multipart_opts.get("root_id")
+        boundary = multipart_opts.get("boundary")
+        encoding = multipart_opts.get("encoding")
+
+        fields = {}
+
+        envelope_headers["Content-ID"] = f"<{root_name}>"
+        envelope_field = (None, etree_to_string(envelope), "text/xml", envelope_headers)
+
+        fields = attachments.to_multipart_field_defs()
+        fields[root_name] = envelope_field
+
+        encoder = MessageMultipartEncoder(fields, boundary=boundary, encoding=encoding)
+
+        return (
+            encoder.to_string(),
+            {
+                "MIME-Version": "1.0",
+                "Content-Transfer-Encoding": f"binary",
+                "Content-Type": f'multipart/related; boundary={boundary}; start="<{root_name}>"',
+            },
+        )
 
     def send(self, client, options, operation, args, kwargs):
         """Called from the service
@@ -120,11 +197,19 @@ class SoapBinding(Binding):
         :type kwargs: dict
 
         """
-        envelope, http_headers = self._create(
+        envelope, http_headers, is_mime_multipart = self._create(
             operation, args, kwargs, client=client, options=options
         )
 
-        response = client.transport.post_xml(options["address"], envelope, http_headers)
+        if not is_mime_multipart:
+            response = client.transport.post_xml(
+                options["address"], envelope, http_headers
+            )
+        else:
+            multipart_request = envelope
+            response = client.transport.post(
+                options["address"], multipart_request, http_headers
+            )
 
         operation_obj = self.get(operation)
 
@@ -150,7 +235,7 @@ class SoapBinding(Binding):
 
         elif response.status_code != 200 and not response.content:
             raise TransportError(
-                u"Server returned HTTP status %d (no content available)"
+                "Server returned HTTP status %d (no content available)"
                 % response.status_code,
                 status_code=response.status_code,
             )


### PR DESCRIPTION
Added a multipart encapsulation for sending attachments to a SOAP server.

Some examples of the current public facing API for attachments:

```python
client = zeep.Client("wsdl-string")
client.service.wsdlService(param0, param1, attachments=[open("attachment-file", "rb")]))
```

The `attachments` kwarg attempts to make it as easy as possible for users to attach files to the request. You can pass an attachment any of the following ways

```python
attachments = [open("attachment-file", "rb")]

attachments = [("attachment-content-id.txt", b"Binary encoding. Assumed utf-8")]

attachments = [("attachment-content-id.txt", b"Binary encoding...", "utf-8")]

attachments = [
    AttachmentEncodable(
        name="attachment-encoded.txt",
        data=b"Binary encoding...",
        content_type="utf-8",
        transfer_encoding="8bit",
    )
]
```
