### PR TITLE
In addition to Body, also sign Timestamp with the provided digest_method

### DIFF
--- a/src/zeep/wsse/signature.py
+++ b/src/zeep/wsse/signature.py
@@ -244,7 +244,7 @@ def _signature_prepare(envelope, key, signature_method, digest_method):
     _sign_node(ctx, signature, envelope.find(QName(soap_env, "Body")), digest_method)
     timestamp = security.find(QName(ns.WSU, "Timestamp"))
     if timestamp != None:
-        _sign_node(ctx, signature, timestamp)
+        _sign_node(ctx, signature, timestamp, digest_method)
     ctx.sign(signature)
 
     # Place the X509 data inside a WSSE SecurityTokenReference within


### PR DESCRIPTION
While implementing a service with zeep, we found out that the optional Timestamp header was always signed using SHA1 instead of the supplied digest_method (SHA256 in our case). This fix will sign both the Body and the Timestamp using the provided digest_method.