### PR TITLE
Improve handling for windows file:// uris

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ install_requires = [
     "lxml>=3.1.0",
     "requests>=2.7.0",
     "requests-toolbelt>=0.7.1",
+    "requests-file>=1.5.1",
     "pytz",
 ]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -132,9 +132,18 @@ def test_create_message():
     assert data is not None
 
 
-def test_load_wsdl_with_file_prefix():
+@pytest.mark.skipif(os.name == "nt", reason="test valid for unix platforms only")
+def test_load_wsdl_with_file_prefix_unix():
     cwd = os.path.dirname(__file__)
     client.Client("file://" + os.path.join(cwd, "wsdl_files/soap.wsdl"))
+
+
+@pytest.mark.skipif(os.name != "nt", reason="test valid for windows platform only")
+def test_load_wsdl_with_file_prefix():
+    cwd = os.path.dirname(__file__)
+    # RFC 8089 REQUIRES that separators in file uris use forward slashes
+    uri = ("file:///" + os.path.join(cwd, "wsdl_files/soap.wsdl")).replace("\\", "/")
+    client.Client(uri)
 
 
 @pytest.mark.requests


### PR DESCRIPTION
- Instead of reinventing the wheel, use a well-known requests plugin
- Treat uris according to RFC8189 appendix E.2
- Add new tests to verify this behaviour on windows and unix

Closes #1133 and closes #666, should allow windows users to properly specify and handle file uris, without breaking current correct support for unix systems.

Limitations
- Does not support non-local files like `file://anotherpc/c:/users/public/example.wsdl`
- Does not support the terse format with implicit "//" like `file:/usr/local/bin`