### PR TITLE
Expose MemorySignature in WSSE package for import

### DIFF
--- a/src/zeep/wsse/__init__.py
+++ b/src/zeep/wsse/__init__.py
@@ -1,3 +1,3 @@
 from .compose import Compose  # noqa
-from .signature import BinarySignature, Signature  # noqa
+from .signature import BinarySignature, Signature, MemorySignature  # noqa
 from .username import UsernameToken  # noqa


### PR DESCRIPTION
A recent commit added MemorySignature to the WSSE package, but it is not imported in the package __init__.py file. Add it so it is available for use.

Closes #1128 