### PR TITLE
Fix unable to resolve when wsdl not prefixed

### DIFF
--- a/tests/test_wsdl.py
+++ b/tests/test_wsdl.py
@@ -390,6 +390,146 @@ def test_wsdl_imports_xsd(recwarn):
     wsdl.Document(content, transport, "http://tests.python-zeep.org/content.wsdl")
 
 
+def test_wsdl_no_prefix_includes_xsd(recwarn):
+    content = StringIO(
+        """
+    <?xml version="1.0"?>
+    <definitions
+      xmlns="http://schemas.xmlsoap.org/wsdl/"
+      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+      xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/"
+      targetNamespace="http://tests.python-zeep.org/x">
+      <types>
+        <xs:schema
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            targetNamespace="http://tests.python-zeep.org/x">
+          <xs:include schemaLocation="a.xsd"/>
+        </xs:schema>
+      </types>
+    </definitions>
+    """.strip()
+    )
+
+    schema_node_a = etree.fromstring(
+        """
+        <?xml version="1.0"?>
+        <xs:schema
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://tests.python-zeep.org/a"
+            xmlns:b="http://tests.python-zeep.org/b"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified">
+          <xs:include schemaLocation="b.xsd"/>
+        </xs:schema>
+    """.strip()
+    )
+
+    schema_node_b = etree.fromstring(
+        """
+        <?xml version="1.0"?>
+        <xs:schema
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://tests.python-zeep.org/b"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified">
+          <xs:element name="BLIST">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="B" type="AHOLDER" maxOccurs="unbounded"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:complexType name="AHOLDER">
+            <xs:sequence>
+              <xs:element name="A" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>The A</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:schema>
+    """.strip()
+    )
+
+    transport = DummyTransport()
+    transport.bind("http://tests.python-zeep.org/a.xsd", schema_node_a)
+    transport.bind("http://tests.python-zeep.org/b.xsd", schema_node_b)
+
+    doc = wsdl.Document(content, transport, "http://tests.python-zeep.org/content.wsdl")
+
+
+def test_wsdl_with_prefix_includes_xsd(recwarn):
+    content = StringIO(
+        """
+    <?xml version="1.0"?>
+    <wsdl:definitions
+      xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+      xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/"
+      targetNamespace="http://tests.python-zeep.org/x">
+      <wsdl:types>
+        <xs:schema
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            targetNamespace="http://tests.python-zeep.org/x">
+          <xs:include schemaLocation="a.xsd"/>
+        </xs:schema>
+      </wsdl:types>
+    </wsdl:definitions>
+    """.strip()
+    )
+
+    schema_node_a = etree.fromstring(
+        """
+        <?xml version="1.0"?>
+        <xs:schema
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://tests.python-zeep.org/a"
+            xmlns:b="http://tests.python-zeep.org/b"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified">
+          <xs:include schemaLocation="b.xsd"/>
+        </xs:schema>
+    """.strip()
+    )
+
+    schema_node_b = etree.fromstring(
+        """
+        <?xml version="1.0"?>
+        <xs:schema
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://tests.python-zeep.org/b"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified">
+          <xs:element name="BLIST">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="B" type="AHOLDER" maxOccurs="unbounded"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:complexType name="AHOLDER">
+            <xs:sequence>
+              <xs:element name="A" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>The A</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:schema>
+    """.strip()
+    )
+
+    transport = DummyTransport()
+    transport.bind("http://tests.python-zeep.org/a.xsd", schema_node_a)
+    transport.bind("http://tests.python-zeep.org/b.xsd", schema_node_b)
+
+    doc = wsdl.Document(content, transport, "http://tests.python-zeep.org/content.wsdl")
+
+
 def test_import_schema_without_location(recwarn):
     content = StringIO(
         """


### PR DESCRIPTION
There's some sort of bug in the type resolution when parsing types.

When the wsdl is using the default namespace e.g. `<definitions>` as opposed to `<wsdl:definitions>` then
```
zeep.exceptions.NamespaceError: No schema available for the namespace 'http://schemas.xmlsoap.org/wsdl/'
```
ends up being raised.

Here, so far I've added two tests, which hopefully illustrate the issue. Pointers or help welcomed.
(Mainly I thought, the tests would be better than just an issue)

`test_wsdl_with_prefix_includes_xsd` passes.
`test_wsdl_no_prefix_includes_xsd` fails like so:

```
src/zeep/wsdl/wsdl.py:90: in __init__
    root_definitions = Definition(self, document, self.location)
src/zeep/wsdl/wsdl.py:190: in __init__
    self.parse_types(doc)
src/zeep/wsdl/wsdl.py:322: in parse_types
    self.types.add_documents(schema_nodes, self.location)
src/zeep/xsd/schema.py:115: in add_documents
    document.resolve()
src/zeep/xsd/schema.py:456: in resolve
    _resolve_dict(self._elements)
src/zeep/xsd/schema.py:437: in _resolve_dict
    new = obj.resolve()
src/zeep/xsd/elements/element.py:306: in resolve
    self.resolve_type()
src/zeep/xsd/elements/element.py:303: in resolve_type
    self.type = self.type.resolve()
src/zeep/xsd/types/complex.py:383: in resolve
    self._element = self._element.resolve()
src/zeep/xsd/elements/indicators.py:222: in resolve
    self[i] = elm.resolve()
src/zeep/xsd/elements/element.py:306: in resolve
    self.resolve_type()
src/zeep/xsd/elements/element.py:303: in resolve_type
    self.type = self.type.resolve()
src/zeep/xsd/types/unresolved.py:36: in resolve
    retval = self.schema.get_type(self.qname)
src/zeep/xsd/schema.py:138: in get_type
    return self._get_instance(qname, "get_type", "type")
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <Schema(location='http://tests.python-zeep.org/content.wsdl', tns='http://tests.python-zeep.org/x')>, qname = <lxml.etree.QName object at 0x109e10a50>, method_name = 'get_type', name = 'type'

    def _get_instance(self, qname, method_name, name):
        """Return an object from one of the SchemaDocument's"""
        qname = self._create_qname(qname)
        try:
            last_exception = None  # type: typing.Optional[BaseException]
            for schema in self._get_schema_documents(qname.namespace):
                method = getattr(schema, method_name)
                try:
                    return method(qname)
                except exceptions.LookupError as exc:
                    last_exception = exc
                    continue
            if last_exception is not None:
                raise last_exception

        except exceptions.NamespaceError:
>           raise exceptions.NamespaceError(
                (
                    "Unable to resolve %s %s. "
                    + "No schema available for the namespace %r."
                )
                % (name, qname.text, qname.namespace)
            )
E           zeep.exceptions.NamespaceError: Unable to resolve type {http://schemas.xmlsoap.org/wsdl/}AHOLDER. No schema available for the namespace 'http://schemas.xmlsoap.org/wsdl/'.

src/zeep/xsd/schema.py:239: NamespaceError
```