### PR TITLE
Remove useless import of aiohttp

### DIFF
--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -3,7 +3,6 @@ import os
 from contextlib import contextmanager
 from urllib.parse import urlparse
 
-import aiohttp
 import requests
 from requests import Response
 from requests_file import FileAdapter


### PR DESCRIPTION
aiohttp is not a dependency so using zeep without it raise an
ImportError.