### PR TITLE
Improve handling of str values for Duration

### DIFF
--- a/src/zeep/xsd/types/builtins.py
+++ b/src/zeep/xsd/types/builtins.py
@@ -122,10 +122,12 @@ class Double(BuiltinType):
 
 class Duration(BuiltinType):
     _default_qname = xsd_ns("duration")
-    accepted_types = [isodate.duration.Duration, str]
+    accepted_types = [isodate.duration.Duration, datetime.timedelta, str]
 
     @check_no_collection
     def xmlvalue(self, value):
+        if isinstance(value, str):
+            value = isodate.parse_duration(value)
         return isodate.duration_isoformat(value)
 
     @treat_whitespace("collapse")

--- a/tests/test_xsd_builtins.py
+++ b/tests/test_xsd_builtins.py
@@ -136,6 +136,10 @@ class TestDuration:
         instance = builtins.Duration()
         value = isodate.parse_duration("P0Y1347M0D")
         assert instance.xmlvalue(value) == "P1347M"
+        assert instance.xmlvalue("P0Y1347M0D") == "P1347M"
+        assert instance.xmlvalue(datetime.timedelta(days=1347)) == "P1347D"
+        with pytest.raises(ValueError):
+            instance.xmlvalue("P15T")
 
     def test_pythonvalue(self):
         instance = builtins.Duration()


### PR DESCRIPTION
Hi @mvantellingen,

I really like your project but recently stumbled into #876 when I wanted to specify a duration as `"PT15M"` and got `"P%P"` in the generated SOAP message.

Here's my attempt to improve the behaviour. Two simple and small test cases are included.
I hope you might consider merging the PR or giving advice if there's another desired way to do things.

In this PR, two things happen:
- Passing in a `datetime.timedelta` value is allowed.
- Passing in a `str` value will result in the `str` being parsed by `isodate.parse_duration()` to ensure the provided value is indeed an iso duration.  
  The result of the parsing is then handed over to `isodate.duration_isoformat()` to produce the desired duration string.  
  This round-trip mimics one of your test cases and results in `builtins.Duration().xmlvalue("P0Y1347M0D") == "P1347M"` where the superfluous zeros are eliminated. This should also ensure that the string is a valid duration in isoformat and raise a `ValueError` if it cannot be parsed as such.

Thanks and best regards,  
Tim