### PR TITLE
Added support for namespaces in SOAP 11 Fault node

### DIFF
--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -324,7 +324,7 @@ class Soap11Binding(SoapBinding):
         def get_text(name):
             child = fault_node.find(name, namespaces=fault_node.nsmap)
             if child is not None:
-                return child.text             
+                return child.text
 
         raise Fault(
             message=get_text("faultstring"),

--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -322,15 +322,15 @@ class Soap11Binding(SoapBinding):
             )
 
         def get_text(name):
-            child = fault_node.find(name)
+            child = fault_node.find(name, namespaces=fault_node.nsmap)
             if child is not None:
-                return child.text
+                return child.text             
 
         raise Fault(
             message=get_text("faultstring"),
             code=get_text("faultcode"),
             actor=get_text("faultactor"),
-            detail=fault_node.find("detail"),
+            detail=fault_node.find("detail", namespaces=fault_node.nsmap),
         )
 
     def _set_http_headers(self, serialized, operation):

--- a/tests/test_wsdl_soap.py
+++ b/tests/test_wsdl_soap.py
@@ -62,6 +62,37 @@ def test_soap11_process_error():
         assert exc.subcodes is None
         assert "detail-message" in etree.tostring(exc.detail).decode("utf-8")
 
+    responseWithNamespaceInFault = load_xml(
+        """
+        <soapenv:Envelope
+            xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+            xmlns:stoc="http://example.com/stockquote.xsd">
+          <soapenv:Body>
+            <soapenv:Fault xmlns="http://schemas.xmlsoap.org/soap/envelope/">
+              <faultcode>fault-code-withNamespace</faultcode>
+              <faultstring>fault-string-withNamespace</faultstring>
+              <detail>
+                <e:myFaultDetails xmlns:e="http://myexample.org/faults">
+                  <e:message>detail-message-withNamespace</e:message>
+                  <e:errorcode>detail-code-withNamespace</e:errorcode>
+                </e:myFaultDetails>
+              </detail>
+            </soapenv:Fault>
+          </soapenv:Body>
+        </soapenv:Envelope>
+    """
+    )
+
+    try:
+        binding.process_error(responseWithNamespaceInFault, None)
+        assert False
+    except Fault as exc:
+        assert exc.message == "fault-string-withNamespace"
+        assert exc.code == "fault-code-withNamespace"
+        assert exc.actor is None
+        assert exc.subcodes is None
+        assert "detail-message-withNamespace" in etree.tostring(exc.detail).decode("utf-8")
+
 
 def test_soap12_process_error():
     response = """


### PR DESCRIPTION
Hello everyone,

# Change Description
Change to fix issue with namespace assertion in SOAP 11 Binding of Faults.
`fault_node.find(name, namespaces=fault_node.nsmap)`