### PR TITLE
docs: fix simple typo, ouput -> output

### DIFF
--- a/src/zeep/wsdl/messages/base.py
+++ b/src/zeep/wsdl/messages/base.py
@@ -12,7 +12,7 @@ SerializedMessage = namedtuple("SerializedMessage", ["path", "headers", "content
 
 
 class ConcreteMessage:
-    """Represents the wsdl:binding -> wsdl:operation -> input/ouput node"""
+    """Represents the wsdl:binding -> wsdl:operation -> input/output node"""
 
     if typing.TYPE_CHECKING:
         body = None  # type: typing.Optional[xsd.Element]


### PR DESCRIPTION
There is a small typo in src/zeep/wsdl/messages/base.py.

Should read `output` rather than `ouput`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md