### PR TITLE
Correction on old python versions note

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,8 +69,9 @@ If you have installed pip then run::
 
     pip install zeep
 
-Note that the latest version to support Python 2.7 and Python 3.5 is Zeep 4.0,
-install via pip install zeep==4.0.0
+
+Note that the latest version to support Python 2.7, 3.3, 3.4 and 3.5 is Zeep 3.4, 
+install via `pip install zeep==3.4.0`
 
 This assumes that there are wheel files available for the latest lxml release.
 If that is not the case (https://pypi.python.org/pypi/lxml/) then first


### PR DESCRIPTION
The README file has the correct note on Zeep 3.4.0 version to install to support old Python versions. The index.rst file was incorrect.