### PR TITLE
Decimal values in scientific notation

### DIFF
--- a/src/zeep/xsd/types/builtins.py
+++ b/src/zeep/xsd/types/builtins.py
@@ -88,6 +88,8 @@ class Decimal(BuiltinType):
 
     @check_no_collection
     def xmlvalue(self, value):
+        if isinstance(value, _Decimal):
+            return "{:f}".format(value)
         return str(value)
 
     @treat_whitespace("collapse")

--- a/tests/test_xsd_builtins.py
+++ b/tests/test_xsd_builtins.py
@@ -83,6 +83,9 @@ class TestDecimal:
         assert instance.xmlvalue(D("10.000002")) == "10.000002"
         assert instance.xmlvalue(D("10")) == "10"
         assert instance.xmlvalue(D("-10")) == "-10"
+        assert instance.xmlvalue(D("1.1E-3")) == "0.0011"
+        assert instance.xmlvalue(D("1.1E+3")) == "1100"
+        assert instance.xmlvalue(D("1.100000000000002E-3")) == "0.001100000000000002"
 
     def test_pythonvalue(self):
         instance = builtins.Decimal()


### PR DESCRIPTION
Hi!

XML Schema Definition (XSD) does not support scientific notation (1.1234e-3) in xsd:decimal by standart. [Some](https://www.w3schools.com/xml/schema_dtypes_numeric.asp) resources doesn't mention scientific notation at all. [Some](http://books.xmlschemata.org/relaxng/ch19-77057.html) mention the restriction directly.

> The decimal separator is always a point (.), and no separation at the thousand mark may be added. There is no support for scientific notation.

Right now `str(value)` in `Decimal` builtin type makes the xml value without beeing aware of this restriction. Here is a small fix and couple of tests for this case. The fix uses Python format `{:f}` method which converts value to Fixed Point string.