### PR TITLE
docs: Add information about http auth for async client

### DIFF
--- a/docs/transport.rst
+++ b/docs/transport.rst
@@ -161,6 +161,27 @@ to the Transport class.
         transport=Transport(session=session))
 
 
+Async HTTP Authentication
+-------------------------
+The Async client for zeep uses a different backend, so the setup is different in this case.
+You will need to use `httpx` to create an :class:`httpx.AsyncClient` object, and pass it to your :class:`zeep.AsyncTransport`.
+
+.. code-block:: python
+
+  import httpx
+  import zeep
+  from zeep.transports import AsyncTransport
+  
+  USER = 'username'
+  PASSWORD = 'password'
+  
+  httpx_client = httpx.AsyncClient(auth=(USER, PASSWORD))
+  
+  aclient = zeep.AsyncClient(
+      "http://my-endpoint.com/production.svc?wsdl",
+      transport=AsyncTransport(client=httpx_client)
+  )
+
 .. _debugging:
 
 Debugging


### PR DESCRIPTION
This solution covers a pretty common use case. It was solved in https://github.com/mvantellingen/python-zeep/issues/1175 but it should be documented somewhere. I tried it and it worked.