### PR TITLE
Pass digest method when signing timestamp node

### DIFF
--- a/src/zeep/wsse/signature.py
+++ b/src/zeep/wsse/signature.py
@@ -244,7 +244,7 @@ def _signature_prepare(envelope, key, signature_method, digest_method):
     _sign_node(ctx, signature, envelope.find(QName(soap_env, "Body")), digest_method)
     timestamp = security.find(QName(ns.WSU, "Timestamp"))
     if timestamp != None:
-        _sign_node(ctx, signature, timestamp)
+        _sign_node(ctx, signature, timestamp, digest_method)
     ctx.sign(signature)
 
     # Place the X509 data inside a WSSE SecurityTokenReference within


### PR DESCRIPTION
This allows a digest method other than the SHA1 default to be used when signing the timestamp node.

I see now that there is an existing similar PR (#1132 ) but I'll add a couple of tests to this one if that one is not moving.