### PR TITLE
Get rid of six

### DIFF
--- a/src/zeep/wsse/username.py
+++ b/src/zeep/wsse/username.py
@@ -2,8 +2,6 @@ import base64
 import hashlib
 import os
 
-import six
-
 from zeep import ns
 from zeep.wsse import utils
 
@@ -108,7 +106,7 @@ class UsernameToken:
             nonce = os.urandom(16)
         timestamp = utils.get_timestamp(self.created, self.zulu_timestamp)
 
-        if isinstance(self.password, six.string_types):
+        if isinstance(self.password, str):
             password = self.password.encode("utf-8")
         else:
             password = self.password


### PR DESCRIPTION
Hi,
It looks like 1ce4e7f2f12461064783ff4dc82f2641172663aa missed one instance where `six` is used.