### PR TITLE
Include pyproject.toml in sdist to avoid pytest warnings

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include CHANGES
 include CONTRIBUTORS.rst
 include LICENSE
 include README.rst
+include pyproject.toml
 include setup.cfg
 include setup.py
 


### PR DESCRIPTION
Hi,
Running tests from the current tarballs results in
> `PytestUnknownMarkWarning: Unknown pytest.mark.requests`.

The marker is defined in `pyproject.toml` which is missing.