### PR TITLE
fix name of choice elements in sequence (issue #1255)

### DIFF
--- a/src/zeep/xsd/elements/indicators.py
+++ b/src/zeep/xsd/elements/indicators.py
@@ -615,7 +615,7 @@ class Sequence(OrderIndicator):
             for elm_name, element in self.elements:
                 try:
                     item_subresult = element.parse_xmlelements(
-                        xmlelements, schema, name, context=context
+                        xmlelements, schema, elm_name, context=context
                     )
                 except UnexpectedElementError:
                     if schema.settings.strict:


### PR DESCRIPTION
Fix + added test case for issue #1255 

Currently zeep fails to parse a schema like the following, telling you that he expects either an "a" or a "b".
            <?xml version="1.0"?>
            <schema xmlns="http://www.w3.org/2001/XMLSchema"
                    xmlns:tns="http://tests.python-zeep.org/"
                    targetNamespace="http://tests.python-zeep.org/"
                    elementFormDefault="qualified">
                <element name="container">
                    <complexType>
                        <sequence>
                            <choice maxOccurs="2">
                                <element name="a" type="string"/>
                                <element name="b" type="string"/>
                            </choice>
                            <choice maxOccurs="2">
                                <element name="c" type="string"/>
                                <element name="d" type="string"/>
                            </choice>
                        </sequence>
                    </complexType>
                </element>
                <element name="a" type="string" />
                <element name="b" type="string" />
            </schema>

The problem is that the value of the second choice overwrites the value of the first one.
