### PR TITLE
Close internal session when transport is deleted

### DIFF
--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -37,6 +37,7 @@ class Transport:
         self.operation_timeout = operation_timeout
         self.logger = logging.getLogger(__name__)
 
+        self.__close_session = not session
         self.session = session or requests.Session()
         self.session.mount("file://", FileAdapter())
         self.session.headers["User-Agent"] = "Zeep/%s (www.python-zeep.org)" % (
@@ -153,6 +154,10 @@ class Transport:
         self.operation_timeout = timeout
         yield
         self.operation_timeout = old_timeout
+
+    def __del__(self):
+        if self.__close_session:
+            self.session.close()
 
 
 class AsyncTransport(Transport):


### PR DESCRIPTION
When using the default session, a "ResourceWarning: unclosed" is raised because the requests session is not closed explicitly.