### PR TITLE
Use stdlib functools.cached_property if available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 install_requires = [
     "attrs>=17.2.0",
-    "cached-property>=1.3.0",
+    "cached-property>=1.3.0; python_version<'3.8'",
     "isodate>=0.5.4",
     "lxml>=4.6.0",
     "platformdirs>=1.4.0",

--- a/src/zeep/wsdl/attachments.py
+++ b/src/zeep/wsdl/attachments.py
@@ -6,7 +6,11 @@ See https://www.w3.org/TR/SOAP-attachments
 
 import base64
 
-from cached_property import cached_property
+try:
+    from functools import cached_property
+except ImportError:
+    from cached_property import cached_property
+
 from requests.structures import CaseInsensitiveDict
 
 

--- a/src/zeep/xsd/elements/indicators.py
+++ b/src/zeep/xsd/elements/indicators.py
@@ -16,7 +16,11 @@ import operator
 import typing
 from collections import OrderedDict, defaultdict, deque
 
-from cached_property import threaded_cached_property
+try:
+    from functools import cached_property as threaded_cached_property
+except ImportError:
+    from cached_property import threaded_cached_property
+
 from lxml import etree
 
 from zeep.exceptions import UnexpectedElementError, ValidationError

--- a/src/zeep/xsd/types/any.py
+++ b/src/zeep/xsd/types/any.py
@@ -1,7 +1,11 @@
 import logging
 import typing
 
-from cached_property import threaded_cached_property
+try:
+    from functools import cached_property as threaded_cached_property
+except ImportError:
+    from cached_property import threaded_cached_property
+
 from lxml import etree
 
 from zeep.utils import qname_attr

--- a/src/zeep/xsd/types/complex.py
+++ b/src/zeep/xsd/types/complex.py
@@ -4,7 +4,11 @@ import typing
 from collections import OrderedDict, deque
 from itertools import chain
 
-from cached_property import threaded_cached_property
+try:
+    from functools import cached_property as threaded_cached_property
+except ImportError:
+    from cached_property import threaded_cached_property
+
 from lxml import etree
 
 from zeep.exceptions import UnexpectedElementError, XMLParseError


### PR DESCRIPTION
Python 3.8+ provides a functools.cached_property in the stdlib that is
thread-safe, i.e. equivalent to threaded_cached_property.  Use it
instead of adding third-party dependencies whenever available.