### PR TITLE
Fix empty SOAPAction header

### DIFF
--- a/src/zeep/wsdl/messages/soap.py
+++ b/src/zeep/wsdl/messages/soap.py
@@ -84,7 +84,11 @@ class SoapMessage(ConcreteMessage):
         # XXX: This is only used in Soap 1.1 so should be moved to the the
         # Soap11Binding._set_http_headers(). But let's keep it like this for
         # now.
-        headers = {"SOAPAction": '"%s"' % self.operation.soapaction}
+        headers = {
+            "SOAPAction": '"%s"' % self.operation.soapaction
+            if self.operation.soapaction
+            else '""'
+        }
         return SerializedMessage(path=None, headers=headers, content=envelope)
 
     def deserialize(self, envelope):


### PR DESCRIPTION
SOAPAction header should never be "None".

When `self.operation.soapaction` is `None` it was stringifyed into `"None"` when it should be `""`.

This fixed the following error when calling a Soap 1.1 service on Camunda:

```xml
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
  <soap:Body>
    <soap:Fault>
      <faultcode>soap:Server</faultcode>
      <faultstring>The given SOAPAction None does not match an operation.</faultstring>
    </soap:Fault>
  </soap:Body>
</soap:Envelope>
```

