### PR TITLE
Fix pytest_httpx test cases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ tests_require = [
     "freezegun==0.3.15",
     "pretend==1.0.9",
     "pytest-cov==2.8.1",
-    "pytest-httpx",
+    "pytest-httpx>=0.14",
     "pytest-asyncio",
     "pytest==6.2.5",
     "requests_mock>=0.7.0",

--- a/tests/test_async_transport.py
+++ b/tests/test_async_transport.py
@@ -19,7 +19,7 @@ def test_load(httpx_mock):
     cache = stub(get=lambda url: None, add=lambda url, content: None)
     transport = AsyncTransport(cache=cache)
 
-    httpx_mock.add_response(url="http://tests.python-zeep.org/test.xml", data="x")
+    httpx_mock.add_response(url="http://tests.python-zeep.org/test.xml", text="x")
     result = transport.load("http://tests.python-zeep.org/test.xml")
     assert result == b"x"
 
@@ -30,7 +30,7 @@ def test_load_cache(httpx_mock):
     cache = InMemoryCache()
     transport = AsyncTransport(cache=cache)
 
-    httpx_mock.add_response(url="http://tests.python-zeep.org/test.xml", data="x")
+    httpx_mock.add_response(url="http://tests.python-zeep.org/test.xml", text="x")
     result = transport.load("http://tests.python-zeep.org/test.xml")
     assert result == b"x"
 
@@ -45,7 +45,7 @@ async def test_post(httpx_mock: HTTPXMock):
 
     envelope = etree.Element("Envelope")
 
-    httpx_mock.add_response(url="http://tests.python-zeep.org/test.xml", data="x")
+    httpx_mock.add_response(url="http://tests.python-zeep.org/test.xml", text="x")
     result = await transport.post_xml(
         "http://tests.python-zeep.org/test.xml", envelope=envelope, headers={}
     )
@@ -67,7 +67,7 @@ async def test_http_error(httpx_mock: HTTPXMock):
     transport = AsyncTransport()
 
     httpx_mock.add_response(
-        url="http://tests.python-zeep.org/test.xml", data="x", status_code=500
+        url="http://tests.python-zeep.org/test.xml", text="x", status_code=500
     )
     with pytest.raises(exceptions.TransportError) as exc:
         transport.load("http://tests.python-zeep.org/test.xml")


### PR DESCRIPTION
The new text keyword was introduced in pytest_httpx 0.14, deprecated
in 0.14 and 0.17 and removed in 0.18.

Thus, an appropriate constraint to that dependency is added.

FWIW, this fixes the test cases on the upcoming Fedora 36 release.

See also:
- https://github.com/Colin-b/pytest_httpx/blob/develop/CHANGELOG.md#0180---2022-01-17
- https://github.com/Colin-b/pytest_httpx/blob/develop/CHANGELOG.md#0140---2021-10-22