### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,9 @@ setup(
     author="Michael van Tellingen",
     author_email="michaelvantellingen@gmail.com",
     url="https://docs.python-zeep.org",
+    project_urls={
+        "Source": "https://github.com/mvantellingen/python-zeep",
+    },
     python_requires=">=3.6",
     install_requires=install_requires,
     tests_require=tests_require,


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.