### PR TITLE
Allow to pass in a pre parsed Document

### DIFF
--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -38,7 +38,7 @@ class Factory:
 class Client:
     """The zeep Client.
 
-    :param wsdl:
+    :param wsdl: Url/local WSDL location or preparsed WSDL Document
     :param wsse:
     :param transport: Custom transport class.
     :param service_name: The service name for the service binding. Defaults to
@@ -70,7 +70,10 @@ class Client:
         self.transport = (
             transport if transport is not None else self._default_transport()
         )
-        self.wsdl = Document(wsdl, self.transport, settings=self.settings)
+        if isinstance(wsdl, Document):
+            self.wsdl = wsdl
+        else:
+            self.wsdl = Document(wsdl, self.transport, settings=self.settings)
         self.wsse = wsse
         self.plugins = plugins if plugins is not None else []
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,11 +5,20 @@ import requests_mock
 
 from tests.utils import load_xml
 from zeep import client, xsd
+from zeep.wsdl import Document
+from zeep.transports import Transport
 from zeep.exceptions import Error
 
 
 def test_bind():
     client_obj = client.Client("tests/wsdl_files/soap.wsdl")
+    service = client_obj.bind()
+    assert service
+
+
+def test_bind_existing_document():
+    wsdl = Document("tests/wsdl_files/soap.wsdl", transport=Transport())
+    client_obj = client.Client(wsdl)
     service = client_obj.bind()
     assert service
 


### PR DESCRIPTION
Although the zeep client has a caching mechanism,
every client instantiation still incurs the overhead of processing the cached WSDL document. 

This PR allows a user to pass in a pre-parsed Document so it can be used by multiple Clients.

I wasn't sure if I should add an example to the docs, since this is a more advanced use case,
but I would be glad to add this if it is useful.  