### PR TITLE
Fix to deserializer if result type does not have a length

### DIFF
--- a/src/zeep/wsdl/messages/soap.py
+++ b/src/zeep/wsdl/messages/soap.py
@@ -116,6 +116,8 @@ class SoapMessage(ConcreteMessage):
             return result
 
         result = result.body
+        if not hasattr(result, '__len__'): # Return body directly if len is allowed (could indicated valid primitive type).
+            return result        
         if result is None or len(result) == 0:
             return None
         elif len(result) > 1:


### PR DESCRIPTION
An exception will be thrown if a bool is returned from a SOAP service call. `deserialize` soap.py will ask for the length of the result body, but it may not be allowed to take len on some result body types. Added check if length is valid and returns the body directly if it is not. I haven't tested with any other types, such as integers.