### PR TITLE
Fix parsing of faults with empty namespace

### DIFF
--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -321,8 +321,15 @@ class Soap11Binding(SoapBinding):
                 detail=etree_to_string(doc),
             )
 
-        def get_text(name):
+        def get_node(name):
             child = fault_node.find(name, namespaces=fault_node.nsmap)
+            if child is not None:
+                return child
+            child = fault_node.find(name)
+            return child
+
+        def get_text(name):
+            child = get_node(name)
             if child is not None:
                 return child.text
 
@@ -330,7 +337,7 @@ class Soap11Binding(SoapBinding):
             message=get_text("faultstring"),
             code=get_text("faultcode"),
             actor=get_text("faultactor"),
-            detail=fault_node.find("detail", namespaces=fault_node.nsmap),
+            detail=get_node("detail"),
         )
 
     def _set_http_headers(self, serialized, operation):

--- a/tests/test_wsdl_soap.py
+++ b/tests/test_wsdl_soap.py
@@ -95,6 +95,39 @@ def test_soap11_process_error():
             "utf-8"
         )
 
+    responseWithEmptyNamespaceInFault = load_xml(
+        """
+        <soapenv:Envelope
+            xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+            xmlns="http://example.com/my/schema">
+          <soapenv:Body>
+            <soapenv:Fault>
+              <faultcode xmlns="">fault-code-withEmptyNamespace</faultcode>
+              <faultstring xmlns="">fault-string-withEmptyNamespace</faultstring>
+              <detail xmlns="">
+                <myFaultDetails xmlns="http://example.com/my/schema">
+                  <message>detail-message-withNamespace</message>
+                  <errorcode>detail-code-withNamespace</errorcode>
+                </myFaultDetails>
+              </detail>
+            </soapenv:Fault>
+          </soapenv:Body>
+        </soapenv:Envelope>
+    """
+    )
+
+    try:
+        binding.process_error(responseWithEmptyNamespaceInFault, None)
+    except Fault as exc:
+        assert exc.message == "fault-string-withEmptyNamespace"
+        assert exc.code == "fault-code-withEmptyNamespace"
+        assert exc.actor is None
+        assert exc.subcodes is None
+        assert "detail-message-withNamespace" in etree.tostring(exc.detail).decode(
+            "utf-8"
+        )
+
+
 
 def test_soap12_process_error():
     response = """


### PR DESCRIPTION
Parsing soap faults falls back to extracting attributes without a namespace, if it can't find a namespaced attribute.

Fixes #1254