### PR TITLE
fixing service creation for AsyncClient in the `elegant` way

### DIFF
--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -51,6 +51,8 @@ class Client:
 
     """
 
+    ServiceProxyClass = ServiceProxy
+
     _default_transport: typing.Union[Transport, AsyncTransport] = Transport
 
     def __init__(
@@ -139,7 +141,7 @@ class Client:
                 "No binding found with the given QName. Available bindings "
                 "are: %s" % (", ".join(self.wsdl.bindings.keys()))
             )
-        return ServiceProxy(self, binding, address=address)
+        return self.ServiceProxyClass(self, binding, address=address)
 
     def create_message(self, service, operation_name, *args, **kwargs):
         """Create the payload for the given operation.
@@ -224,6 +226,8 @@ class Client:
 
 class AsyncClient(Client):
     _default_transport = AsyncTransport
+
+    ServiceProxyClass = AsyncServiceProxy
 
     def bind(
         self,


### PR DESCRIPTION
This pull request is intended to fix issue with AsyncClient.create_service, which returns a service that can`t be used (mentioned in issue #1168 
There also is PR #1202 solving the same issue. This PR presents the way that was suggested in a comment for that PR. 
@mvantellingen, is this OK and can this be merged please?