### PR TITLE
Fix Settings access for Python 3.12

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Zeep: Python SOAP client
 A Python SOAP client
 
 Highlights:
- * Compatible with Python 3.7, 3.8, 3.9, 3.10, 3.11 and PyPy3
+ * Compatible with Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12 and PyPy3
  * Build on top of lxml, requests and httpx
  * Support for Soap 1.1, Soap 1.2 and HTTP bindings
  * Support for WS-Addressing headers

--- a/src/zeep/settings.py
+++ b/src/zeep/settings.py
@@ -76,6 +76,7 @@ class Settings:
                     setattr(self._tls, key, value)
 
     def __getattribute__(self, key):
-        if key != "_tls" and hasattr(self._tls, key):
-            return getattr(self._tls, key)
-        return super().__getattribute__(key)
+        _tls = object.__getattribute__(self, "_tls")
+        if key != "_tls" and hasattr(_tls, key):
+            return getattr(_tls, key)
+        return object.__getattribute__(self, key)


### PR DESCRIPTION
Trying to read attributes from the `Settings` object in Python 3.12 is causing an infinite recursion loop. 

Tested working on 3.12 and 3.10