### PR TITLE
drop python<=3.7 support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Zeep documentation build configuration file, created by
 # sphinx-quickstart on Fri Mar  4 16:51:06 2016.
@@ -52,9 +51,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Zeep'
-copyright = u'2016, <a href="https://www.mvantellingen.nl/">Michael van Tellingen</a>'
-author = u'Michael van Tellingen'
+project = 'Zeep'
+copyright = '2016, <a href="https://www.mvantellingen.nl/">Michael van Tellingen</a>'
+author = 'Michael van Tellingen'
 
 
 # The version info for the project you're documenting, acts as replacement for
@@ -249,8 +248,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Zeep.tex', u'Zeep Documentation',
-     u'Michael van Tellingen', 'manual'),
+    (master_doc, 'Zeep.tex', 'Zeep Documentation',
+     'Michael van Tellingen', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -293,7 +292,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Zeep', u'Zeep Documentation',
+    (master_doc, 'Zeep', 'Zeep Documentation',
      author, 'Zeep', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,9 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
-import pkg_resources
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/examples/async_client.py
+++ b/examples/async_client.py
@@ -1,10 +1,8 @@
 import asyncio
-import httpx
 import time
 
 import zeep
 
-from zeep.transports import AsyncTransport
 
 
 def run_async():

--- a/examples/code39.py
+++ b/examples/code39.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import zeep
 
 client = zeep.Client(

--- a/examples/eu_vat_service.py
+++ b/examples/eu_vat_service.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import zeep
 
 

--- a/examples/http_basic_auth.py
+++ b/examples/http_basic_auth.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from requests import Session
 from requests.auth import HTTPBasicAuth
 

--- a/examples/km_to_miles.py
+++ b/examples/km_to_miles.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import zeep
 
 

--- a/examples/soap_server.py
+++ b/examples/soap_server.py
@@ -21,7 +21,7 @@ class ExampleService(ServiceBase):
     @rpc(Unicode, _returns=Unicode)
     def slow_request(ctx, request_id):
         time.sleep(1)
-        return u'Request: %s' % request_id
+        return 'Request: %s' % request_id
 
 application = Application(
     services=[ExampleService],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from setuptools import setup
 
 install_requires = [
     "attrs>=17.2.0",
-    "cached-property>=1.3.0; python_version<'3.8'",
     "isodate>=0.5.4",
     "lxml>=4.6.0",
     "platformdirs>=1.4.0",
@@ -58,7 +57,7 @@ setup(
     project_urls={
         "Source": "https://github.com/mvantellingen/python-zeep",
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=install_requires,
     tests_require=tests_require,
     extras_require={
@@ -75,13 +74,11 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],

--- a/src/zeep/__main__.py
+++ b/src/zeep/__main__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import argparse
 import logging
 import logging.config

--- a/src/zeep/cache.py
+++ b/src/zeep/cache.py
@@ -79,7 +79,7 @@ class InMemoryCache(Base):
         logger.debug("Caching contents of %s", url)
         if not isinstance(content, (str, bytes)):
             raise TypeError(
-                "a bytes-like object is required, not {}".format(type(content).__name__)
+                f"a bytes-like object is required, not {type(content).__name__}"
             )
         self._cache[url] = (datetime.datetime.utcnow(), content)
 

--- a/src/zeep/cache.py
+++ b/src/zeep/cache.py
@@ -4,7 +4,6 @@ import errno
 import logging
 import os
 import threading
-import typing
 from contextlib import contextmanager
 
 import platformdirs

--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -32,7 +32,7 @@ class Factory:
         :rtype: zeep.xsd.ComplexType or zeep.xsd.AnySimpleType
 
         """
-        return self._method("{%s}%s" % (self._ns, key))
+        return self._method("{{{}}}{}".format(self._ns, key))
 
 
 class Client:

--- a/src/zeep/exceptions.py
+++ b/src/zeep/exceptions.py
@@ -4,7 +4,7 @@ class Error(Exception):
         self.message = message
 
     def __repr__(self):
-        return "%s(%r)" % (self.__class__.__name__, self.message)
+        return "{}({!r})".format(self.__class__.__name__, self.message)
 
 
 class XMLSyntaxError(Error):
@@ -22,9 +22,9 @@ class XMLParseError(Error):
     def __str__(self):
         location = None
         if self.filename and self.sourceline:
-            location = "%s:%s" % (self.filename, self.sourceline)
+            location = "{}:{}".format(self.filename, self.sourceline)
         if location:
-            return "%s (%s)" % (self.message, location)
+            return "{} ({})".format(self.message, location)
         return self.message
 
 
@@ -77,7 +77,7 @@ class ValidationError(Error):
     def __str__(self):
         if self.path:
             path = ".".join(str(x) for x in self.path)
-            return "%s (%s)" % (self.message, path)
+            return "{} ({})".format(self.message, path)
         return self.message
 
 
@@ -95,7 +95,7 @@ class IncompleteOperation(Error):
 
 class DTDForbidden(Error):
     def __init__(self, name, sysid, pubid):
-        super(DTDForbidden, self).__init__()
+        super().__init__()
         self.name = name
         self.sysid = sysid
         self.pubid = pubid
@@ -107,7 +107,7 @@ class DTDForbidden(Error):
 
 class EntitiesForbidden(Error):
     def __init__(self, name, content):
-        super(EntitiesForbidden, self).__init__()
+        super().__init__()
         self.name = name
         self.content = content
 

--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -211,7 +211,7 @@ class AsyncTransport(Transport):
 
         try:
             response.raise_for_status()
-        except httpx.HTTPStatusError as exc:
+        except httpx.HTTPStatusError:
             raise TransportError(status_code=response.status_code)
         return result
 

--- a/src/zeep/utils.py
+++ b/src/zeep/utils.py
@@ -33,7 +33,7 @@ def as_qname(value: str, nsmap, target_namespace=None) -> etree.QName:
             namespace = nsmap.get(prefix)
 
         if not namespace:
-            raise XMLParseError("No namespace defined for %r (%r)" % (prefix, value))
+            raise XMLParseError("No namespace defined for {!r} ({!r})".format(prefix, value))
 
         # Workaround for https://github.com/mvantellingen/python-zeep/issues/349
         if not local:

--- a/src/zeep/wsdl/attachments.py
+++ b/src/zeep/wsdl/attachments.py
@@ -7,10 +7,7 @@ See https://www.w3.org/TR/SOAP-attachments
 import base64
 import sys
 
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    from cached_property import cached_property
+from functools import cached_property
 
 from requests.structures import CaseInsensitiveDict
 
@@ -65,7 +62,7 @@ class Attachment:
         self._part = part
 
     def __repr__(self):
-        return "<Attachment(%r, %r)>" % (self.content_id, self.content_type)
+        return "<Attachment({!r}, {!r})>".format(self.content_id, self.content_type)
 
     @cached_property
     def content(self):

--- a/src/zeep/wsdl/attachments.py
+++ b/src/zeep/wsdl/attachments.py
@@ -5,7 +5,6 @@ See https://www.w3.org/TR/SOAP-attachments
 """
 
 import base64
-import sys
 
 from functools import cached_property
 

--- a/src/zeep/wsdl/definitions.py
+++ b/src/zeep/wsdl/definitions.py
@@ -49,7 +49,7 @@ class AbstractMessage:
         self.parts = OrderedDict()
 
     def __repr__(self):
-        return "<%s(name=%r)>" % (self.__class__.__name__, self.name.text)
+        return "<{}(name={!r})>".format(self.__class__.__name__, self.name.text)
 
     def resolve(self, definitions):
         pass
@@ -98,7 +98,7 @@ class PortType:
         self.operations = operations
 
     def __repr__(self):
-        return "<%s(name=%r)>" % (self.__class__.__name__, self.name.text)
+        return "<{}(name={!r})>".format(self.__class__.__name__, self.name.text)
 
     def resolve(self, definitions):
         pass
@@ -151,10 +151,10 @@ class Binding:
         self._operations[operation.name] = operation
 
     def __str__(self):
-        return "%s: %s" % (self.__class__.__name__, self.name.text)
+        return "{}: {}".format(self.__class__.__name__, self.name.text)
 
     def __repr__(self):
-        return "<%s(name=%r, port_type=%r)>" % (
+        return "<{}(name={!r}, port_type={!r})>".format(
             self.__class__.__name__,
             self.name.text,
             self.port_type,
@@ -167,7 +167,7 @@ class Binding:
         try:
             return self._operations[key]
         except KeyError:
-            raise ValueError("No such operation %r on %s" % (key, self.name))
+            raise ValueError("No such operation {!r} on {}".format(key, self.name))
 
     @classmethod
     def match(cls, node):
@@ -204,7 +204,7 @@ class Operation:
             )
 
     def __repr__(self):
-        return "<%s(name=%r, style=%r)>" % (
+        return "<{}(name={!r}, style={!r})>".format(
             self.__class__.__name__,
             self.name,
             self.style,
@@ -214,7 +214,7 @@ class Operation:
         if not self.input:
             return "%s(missing input message)" % (self.name)
 
-        retval = "%s(%s)" % (self.name, self.input.signature())
+        retval = "{}({})".format(self.name, self.input.signature())
         if self.output:
             retval += " -> %s" % (self.output.signature(as_output=True))
         return retval
@@ -267,7 +267,7 @@ class Port:
         self.binding_options = {}
 
     def __repr__(self):
-        return "<%s(name=%r, binding=%r, %r)>" % (
+        return "<{}(name={!r}, binding={!r}, {!r})>".format(
             self.__class__.__name__,
             self.name,
             self.binding,
@@ -275,7 +275,7 @@ class Port:
         )
 
     def __str__(self):
-        return "Port: %s (%s)" % (self.name, self.binding)
+        return "Port: {} ({})".format(self.name, self.binding)
 
     def resolve(self, definitions):
         if self._resolve_context is None:
@@ -312,7 +312,7 @@ class Service:
         return "Service: %s" % self.name
 
     def __repr__(self):
-        return "<%s(name=%r, ports=%r)>" % (
+        return "<{}(name={!r}, ports={!r})>".format(
             self.__class__.__name__,
             self.name,
             self.ports,

--- a/src/zeep/wsdl/messages/multiref.py
+++ b/src/zeep/wsdl/messages/multiref.py
@@ -122,7 +122,7 @@ def _prefix_node(node):
             namespace, localname = match.groups()
 
             if namespace in reverse_nsmap:
-                value = "%s:%s" % (reverse_nsmap.get(namespace), localname)
+                value = "{}:{}".format(reverse_nsmap.get(namespace), localname)
                 node.set(key, value)
 
 
@@ -151,6 +151,6 @@ def _get_attributes(node):
 
             if prefix in nsmap:
                 namespace = nsmap[prefix]
-                value = "{%s}%s" % (namespace, localname)
+                value = "{{{}}}{}".format(namespace, localname)
         result[key] = value
     return list(result.items())

--- a/src/zeep/wsdl/wsdl.py
+++ b/src/zeep/wsdl/wsdl.py
@@ -18,7 +18,6 @@ from zeep.loader import (
     absolute_location,
     is_relative_path,
     load_external,
-    load_external_async,
 )
 from zeep.settings import Settings
 from zeep.utils import findall_multiple_ns

--- a/src/zeep/wsdl/wsdl.py
+++ b/src/zeep/wsdl/wsdl.py
@@ -3,7 +3,6 @@
     ~~~~~~~~~~~~~~
 
 """
-from __future__ import print_function
 
 import logging
 import operator
@@ -110,7 +109,7 @@ class Document:
         print("")
         print("Prefixes:")
         for prefix, namespace in self.types.prefix_map.items():
-            print(" " * 4, "%s: %s" % (prefix, namespace))
+            print(" " * 4, "{}: {}".format(prefix, namespace))
 
         print("")
         print("Global elements:")
@@ -141,7 +140,7 @@ class Document:
                 )
 
                 for operation in operations:
-                    print("%s%s" % (" " * 12, str(operation)))
+                    print("{}{}".format(" " * 12, str(operation)))
                 print("")
 
     def _get_xml_document(self, location: typing.IO) -> etree._Element:
@@ -202,7 +201,7 @@ class Definition:
         self.services = self.parse_service(doc)
 
     def __repr__(self):
-        return "<%s(location=%r)>" % (self.__class__.__name__, self.location)
+        return "<{}(location={!r})>".format(self.__class__.__name__, self.location)
 
     def get(self, name, key, _processed=None):
         container = getattr(self, name)
@@ -229,7 +228,7 @@ class Definition:
                     except IndexError:
                         pass
 
-        raise IndexError("No definition %r in %r found" % (key, name))
+        raise IndexError("No definition {!r} in {!r} found".format(key, name))
 
     def resolve_imports(self) -> None:
         """Resolve all root elements (types, messages, etc)."""

--- a/src/zeep/wsse/utils.py
+++ b/src/zeep/wsse/utils.py
@@ -37,7 +37,7 @@ def get_timestamp(timestamp=None, zulu_timestamp=None):
 
 
 def get_unique_id():
-    return "id-{0}".format(uuid4())
+    return f"id-{uuid4()}"
 
 
 def ensure_id(node):

--- a/src/zeep/xsd/elements/any.py
+++ b/src/zeep/xsd/elements/any.py
@@ -44,7 +44,7 @@ class Any(Base):
         return any_object
 
     def __repr__(self):
-        return "<%s(name=%r)>" % (self.__class__.__name__, self.name)
+        return "<{}(name={!r})>".format(self.__class__.__name__, self.name)
 
     def accept(self, value):
         return True
@@ -207,8 +207,8 @@ class Any(Base):
                 )
 
         elif not isinstance(value, tuple(expected_types)):
-            type_names = ["%s.%s" % (t.__module__, t.__name__) for t in expected_types]
-            err_message = "Any element received object of type %r, expected %s" % (
+            type_names = ["{}.{}".format(t.__module__, t.__name__) for t in expected_types]
+            err_message = "Any element received object of type {!r}, expected {}".format(
                 type(value).__name__,
                 " or ".join(type_names),
             )

--- a/src/zeep/xsd/elements/attribute.py
+++ b/src/zeep/xsd/elements/attribute.py
@@ -38,7 +38,7 @@ class Attribute(Element):
             self.type.validate(value, required=self.required)
         except exceptions.ValidationError as exc:
             raise exceptions.ValidationError(
-                "The attribute %s is not valid: %s" % (self.qname, exc.message),
+                "The attribute {} is not valid: {}".format(self.qname, exc.message),
                 path=render_path,
             )
 

--- a/src/zeep/xsd/elements/builtins.py
+++ b/src/zeep/xsd/elements/builtins.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from zeep.xsd.const import xsd_ns
 from zeep.xsd.elements.base import Base
 

--- a/src/zeep/xsd/elements/element.py
+++ b/src/zeep/xsd/elements/element.py
@@ -49,9 +49,9 @@ class Element(Base):
     def __str__(self):
         if self.type:
             if self.type.is_global:
-                return "%s(%s)" % (self.name, self.type.qname)
+                return "{}({})".format(self.name, self.type.qname)
             else:
-                return "%s(%s)" % (self.name, self.type.signature())
+                return "{}({})".format(self.name, self.type.signature())
         return "%s()" % self.name
 
     def __call__(self, *args, **kwargs):
@@ -61,7 +61,7 @@ class Element(Base):
         return instance
 
     def __repr__(self):
-        return "<%s(name=%r, type=%r)>" % (
+        return "<{}(name={!r}, type={!r})>".format(
             self.__class__.__name__,
             self.name,
             self.type,
@@ -295,7 +295,7 @@ class Element(Base):
             self.type.validate(value, required=True)
         except exceptions.ValidationError as exc:
             raise exceptions.ValidationError(
-                "The element %s is not valid: %s" % (self.qname, exc.message),
+                "The element {} is not valid: {}".format(self.qname, exc.message),
                 path=render_path,
             )
 
@@ -318,7 +318,7 @@ class Element(Base):
                 value = "{%s}" % value
 
         if standalone:
-            value = "%s(%s)" % (self.get_prefixed_name(schema), value)
+            value = "{}({})".format(self.get_prefixed_name(schema), value)
 
         if self.accepts_multiple:
             return "%s[]" % value

--- a/src/zeep/xsd/elements/indicators.py
+++ b/src/zeep/xsd/elements/indicators.py
@@ -13,13 +13,10 @@ All, Choice, Group and Sequence.
 """
 import copy
 import operator
-import sys
-import typing
 from collections import OrderedDict, defaultdict, deque
 
 from functools import cached_property as threaded_cached_property
 
-from lxml import etree
 
 from zeep.exceptions import UnexpectedElementError, ValidationError
 from zeep.xsd.const import NotSet, SkipValue

--- a/src/zeep/xsd/elements/indicators.py
+++ b/src/zeep/xsd/elements/indicators.py
@@ -17,10 +17,7 @@ import sys
 import typing
 from collections import OrderedDict, defaultdict, deque
 
-if sys.version_info >= (3, 8):
-    from functools import cached_property as threaded_cached_property
-else:
-    from cached_property import threaded_cached_property
+from functools import cached_property as threaded_cached_property
 
 from lxml import etree
 
@@ -42,7 +39,7 @@ class Indicator(Base):
     """Base class for the other indicators"""
 
     def __repr__(self):
-        return "<%s(%s)>" % (self.__class__.__name__, super().__repr__())
+        return "<{}({})>".format(self.__class__.__name__, super().__repr__())
 
     @property
     def default_value(self):
@@ -267,12 +264,12 @@ class OrderIndicator(Indicator, list):
                 parts.append(element.signature(schema, standalone=False))
             else:
                 value = element.signature(schema, standalone=False)
-                parts.append("%s: %s" % (name, value))
+                parts.append("{}: {}".format(name, value))
 
         part = ", ".join(parts)
 
         if self.accepts_multiple:
-            return "[%s]" % (part,)
+            return "[{}]".format(part)
         return part
 
 
@@ -579,11 +576,11 @@ class Choice(OrderIndicator):
                 parts.append("{%s}" % (element.signature(schema, standalone=False)))
             else:
                 parts.append(
-                    "{%s: %s}" % (name, element.signature(schema, standalone=False))
+                    "{{{}: {}}}".format(name, element.signature(schema, standalone=False))
                 )
         part = "(%s)" % " | ".join(parts)
         if self.accepts_multiple:
-            return "%s[]" % (part,)
+            return "{}[]".format(part)
         return part
 
 
@@ -661,8 +658,7 @@ class Group(Indicator):
         return self.signature()
 
     def __iter__(self, *args, **kwargs):
-        for item in self.child:
-            yield item
+        yield from self.child
 
     @threaded_cached_property
     def elements(self):
@@ -758,6 +754,6 @@ class Group(Indicator):
     def signature(self, schema=None, standalone=True):
         name = create_prefixed_name(self.qname, schema)
         if standalone:
-            return "%s(%s)" % (name, self.child.signature(schema, standalone=False))
+            return "{}({})".format(name, self.child.signature(schema, standalone=False))
         else:
             return self.child.signature(schema, standalone=False)

--- a/src/zeep/xsd/schema.py
+++ b/src/zeep/xsd/schema.py
@@ -47,7 +47,7 @@ class Schema:
     def __repr__(self):
         main_doc = self.root_document
         if main_doc:
-            return "<Schema(location=%r, tns=%r)>" % (
+            return "<Schema(location={!r}, tns={!r})>".format(
                 main_doc._location,
                 main_doc._target_namespace,
             )
@@ -303,8 +303,7 @@ class _SchemaContainer:
         self._instances = OrderedDict()
 
     def __iter__(self):
-        for document in self.values():
-            yield document
+        yield from self.values()
 
     def add(self, document: "SchemaDocument") -> None:
         """Add a schema document"""
@@ -348,8 +347,7 @@ class _SchemaContainer:
 
     def values(self):
         for documents in self._instances.values():
-            for document in documents:
-                yield document
+            yield from documents
 
 
 class SchemaDocument:
@@ -384,7 +382,7 @@ class SchemaDocument:
         # self._xml_schema = None
 
     def __repr__(self):
-        return "<SchemaDocument(location=%r, tns=%r, is_empty=%r)>" % (
+        return "<SchemaDocument(location={!r}, tns={!r}, is_empty={!r})>".format(
             self._location,
             self._target_namespace,
             self.is_empty,

--- a/src/zeep/xsd/types/any.py
+++ b/src/zeep/xsd/types/any.py
@@ -2,10 +2,7 @@ import logging
 import sys
 import typing
 
-if sys.version_info >= (3, 8):
-    from functools import cached_property as threaded_cached_property
-else:
-    from cached_property import threaded_cached_property
+from functools import cached_property as threaded_cached_property
 
 from lxml import etree
 

--- a/src/zeep/xsd/types/any.py
+++ b/src/zeep/xsd/types/any.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 import typing
 
 from functools import cached_property as threaded_cached_property

--- a/src/zeep/xsd/types/builtins.py
+++ b/src/zeep/xsd/types/builtins.py
@@ -89,7 +89,7 @@ class Decimal(BuiltinType):
     @check_no_collection
     def xmlvalue(self, value):
         if isinstance(value, _Decimal):
-            return "{:f}".format(value)
+            return f"{value:f}"
         return str(value)
 
     @treat_whitespace("collapse")

--- a/src/zeep/xsd/types/complex.py
+++ b/src/zeep/xsd/types/complex.py
@@ -8,10 +8,7 @@ from collections import OrderedDict, deque
 from itertools import chain
 from typing import Optional
 
-if sys.version_info >= (3, 8):
-    from functools import cached_property as threaded_cached_property
-else:
-    from cached_property import threaded_cached_property
+from functools import cached_property as threaded_cached_property
 
 from lxml import etree
 
@@ -47,7 +44,7 @@ _ObjectList = typing.List[typing.Union[CompoundValue, None, "_ObjectList"]]
 
 
 class ComplexType(AnyType):
-    _xsd_name: typing.Optional[str] = None
+    _xsd_name: str | None = None
 
     def __init__(
         self,
@@ -66,7 +63,7 @@ class ComplexType(AnyType):
         self._attributes = attributes or []
         self._restriction = restriction
         self._extension = extension
-        self._extension_types: typing.List[typing.Type] = []
+        self._extension_types: list[type] = []
         super().__init__(qname=qname, is_global=is_global)
 
     def __call__(self, *args, **kwargs):
@@ -75,11 +72,11 @@ class ComplexType(AnyType):
         return self._value_class(*args, **kwargs)
 
     @property
-    def accepted_types(self) -> typing.List[typing.Type]:
+    def accepted_types(self) -> list[type]:
         return [self._value_class] + self._extension_types
 
     @threaded_cached_property
-    def _array_class(self) -> typing.Type[ArrayValue]:
+    def _array_class(self) -> type[ArrayValue]:
         assert self._array_type
         return type(
             self.__class__.__name__,
@@ -88,7 +85,7 @@ class ComplexType(AnyType):
         )
 
     @threaded_cached_property
-    def _value_class(self) -> typing.Type[CompoundValue]:
+    def _value_class(self) -> type[CompoundValue]:
         return type(
             self.__class__.__name__,
             (CompoundValue,),
@@ -96,7 +93,7 @@ class ComplexType(AnyType):
         )
 
     def __str__(self):
-        return "%s(%s)" % (self.__class__.__name__, self.signature())
+        return "{}({})".format(self.__class__.__name__, self.signature())
 
     @threaded_cached_property
     def attributes(self):
@@ -174,11 +171,11 @@ class ComplexType(AnyType):
     def parse_xmlelement(
         self,
         xmlelement: etree._Element,
-        schema: Optional[Schema] = None,
+        schema: Schema | None = None,
         allow_none: bool = True,
         context: XmlParserContext = None,
-        schema_type: Optional[Type] = None,
-    ) -> typing.Optional[typing.Union[str, CompoundValue, typing.List[etree._Element]]]:
+        schema_type: Type | None = None,
+    ) -> str | CompoundValue | list[etree._Element] | None:
         """Consume matching xmlelements and call parse() on each
 
         :param xmlelement: XML element objects
@@ -250,8 +247,8 @@ class ComplexType(AnyType):
     def render(
         self,
         node: etree._Element,
-        value: typing.Union[list, dict, CompoundValue],
-        xsd_type: "ComplexType" = None,
+        value: list | dict | CompoundValue,
+        xsd_type: ComplexType = None,
         render_path=None,
     ) -> None:
         """Serialize the given value lxml.Element subelements on the node
@@ -314,10 +311,10 @@ class ComplexType(AnyType):
 
     def parse_kwargs(
         self,
-        kwargs: typing.Dict[str, typing.Any],
+        kwargs: dict[str, typing.Any],
         name: str,
-        available_kwargs: typing.Set[str],
-    ) -> typing.Dict[str, typing.Any]:
+        available_kwargs: set[str],
+    ) -> dict[str, typing.Any]:
         """Parse the kwargs for this type and return the accepted data as
         a dict.
 
@@ -341,8 +338,8 @@ class ComplexType(AnyType):
         return {}
 
     def _create_object(
-        self, value: typing.Union[list, dict, CompoundValue, None], name: str
-    ) -> typing.Union[CompoundValue, None, _ObjectList]:
+        self, value: list | dict | CompoundValue | None, name: str
+    ) -> CompoundValue | None | _ObjectList:
         """Return the value as a CompoundValue object
 
         :type value: str
@@ -507,11 +504,11 @@ class ComplexType(AnyType):
             parts.append(part)
 
         for name, attribute in self.attributes:
-            part = "%s: %s" % (name, attribute.signature(schema, standalone=False))
+            part = "{}: {}".format(name, attribute.signature(schema, standalone=False))
             parts.append(part)
 
         value = ", ".join(parts)
         if standalone:
-            return "%s(%s)" % (self.get_prefixed_name(schema), value)
+            return "{}({})".format(self.get_prefixed_name(schema), value)
         else:
             return value

--- a/src/zeep/xsd/types/complex.py
+++ b/src/zeep/xsd/types/complex.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 import copy
 import logging
-import sys
 import typing
 from collections import OrderedDict, deque
 from itertools import chain
-from typing import Optional
 
 from functools import cached_property as threaded_cached_property
 

--- a/src/zeep/xsd/types/unresolved.py
+++ b/src/zeep/xsd/types/unresolved.py
@@ -18,7 +18,7 @@ class UnresolvedType(Type):
         self.schema = schema
 
     def __repr__(self):
-        return "<%s(qname=%r)>" % (self.__class__.__name__, self.qname.text)
+        return "<{}(qname={!r})>".format(self.__class__.__name__, self.qname.text)
 
     def render(
         self,
@@ -46,7 +46,7 @@ class UnresolvedCustomType(Type):
         self.base_type = base_type
 
     def __repr__(self):
-        return "<%s(qname=%r, base_type=%r)>" % (
+        return "<{}(qname={!r}, base_type={!r})>".format(
             self.__class__.__name__,
             self.qname.text,
             self.base_type,

--- a/src/zeep/xsd/utils.py
+++ b/src/zeep/xsd/utils.py
@@ -33,8 +33,7 @@ def max_occurs_iter(max_occurs, items=None):
         for i, sub_kwargs in zip(generator, items):
             yield sub_kwargs
     else:
-        for i in generator:
-            yield i
+        yield from generator
 
 
 def create_prefixed_name(qname, schema):
@@ -51,10 +50,10 @@ def create_prefixed_name(qname, schema):
     if schema and qname.namespace:
         prefix = schema.get_shorthand_for_ns(qname.namespace)
         if prefix:
-            return "%s:%s" % (prefix, qname.localname)
+            return "{}:{}".format(prefix, qname.localname)
     elif qname.namespace in ns.NAMESPACE_TO_PREFIX:
         prefix = ns.NAMESPACE_TO_PREFIX[qname.namespace]
-        return "%s:%s" % (prefix, qname.localname)
+        return "{}:{}".format(prefix, qname.localname)
 
     if qname.namespace:
         return qname.text

--- a/src/zeep/xsd/valueobjects.py
+++ b/src/zeep/xsd/valueobjects.py
@@ -24,7 +24,7 @@ class AnyObject:
         self.value = value
 
     def __repr__(self):
-        return "<%s(type=%r, value=%r)>" % (
+        return "<{}(type={!r}, value={!r})>".format(
             self.__class__.__name__,
             self.xsd_elm,
             self.value,
@@ -154,7 +154,7 @@ class CompoundValue:
             return self.__values__[key]
         except KeyError:
             raise AttributeError(
-                "%s instance has no attribute '%s'" % (self.__class__.__name__, key)
+                "{} instance has no attribute '{}'".format(self.__class__.__name__, key)
             )
 
     def __deepcopy__(self, memo):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import sys
 
 import pytest
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -60,7 +60,7 @@ def test_context_manager():
 def test_service_proxy_dir_operations():
     client_obj = client.Client("tests/wsdl_files/soap.wsdl")
     operations = [op for op in dir(client_obj.service) if not op.startswith("_")]
-    assert set(operations) == set(["GetLastTradePrice", "GetLastTradePriceNoOutput"])
+    assert set(operations) == {"GetLastTradePrice", "GetLastTradePriceNoOutput"}
 
 
 def test_operation_proxy_doc():

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,5 +1,4 @@
 import pytest
-from pytest import raises as assert_raises
 
 from tests.utils import DummyTransport
 from zeep.exceptions import DTDForbidden, EntitiesForbidden

--- a/tests/test_soap_xop.py
+++ b/tests/test_soap_xop.py
@@ -249,7 +249,7 @@ def test_xop():
             headers={"Content-Type": content_type},
         )
         result = service.TestOperation2("")
-        assert result["_value_1"] == "BINARYDATA".encode()
+        assert result["_value_1"] == b"BINARYDATA"
 
         m.post(
             "http://tests.python-zeep.org/test",
@@ -257,7 +257,7 @@ def test_xop():
             headers={"Content-Type": content_type},
         )
         result = service.TestOperation1("")
-        assert result == "BINARYDATA".encode()
+        assert result == b"BINARYDATA"
 
 
 def test_xop_cid_encoded():
@@ -302,4 +302,4 @@ def test_xop_cid_encoded():
             headers={"Content-Type": content_type},
         )
         result = service.TestOperation2("")
-        assert result["_value_1"] == "BINARYDATA".encode()
+        assert result["_value_1"] == b"BINARYDATA"

--- a/tests/test_wsdl.py
+++ b/tests/test_wsdl.py
@@ -159,7 +159,7 @@ def test_parse_types_multiple_schemas():
 
 def test_parse_types_nsmap_issues():
     content = StringIO(
-        """
+        r"""
     <?xml version="1.0"?>
     <wsdl:definitions targetNamespace="urn:ec.europa.eu:taxud:vies:services:checkVat"
       xmlns:tns1="urn:ec.europa.eu:taxud:vies:services:checkVat:types"
@@ -199,7 +199,7 @@ def test_parse_types_nsmap_issues():
 @pytest.mark.requests
 def test_parse_soap_import_wsdl():
     client = stub(transport=Transport(), wsse=None)
-    content = io.open("tests/wsdl_files/soap-enc.xsd", "r", encoding="utf-8").read()
+    content = open("tests/wsdl_files/soap-enc.xsd", encoding="utf-8").read()
 
     with requests_mock.mock() as m:
         m.get("http://schemas.xmlsoap.org/soap/encoding/", text=content)

--- a/tests/test_wsdl.py
+++ b/tests/test_wsdl.py
@@ -1,4 +1,3 @@
-import io
 from io import StringIO
 
 import pytest

--- a/tests/test_wsdl_arrays.py
+++ b/tests/test_wsdl_arrays.py
@@ -12,7 +12,7 @@ def transport():
     transport = DummyTransport()
     transport.bind(
         "http://schemas.xmlsoap.org/soap/encoding/",
-        load_xml(io.open("tests/wsdl_files/soap-enc.xsd", "r").read().encode("utf-8")),
+        load_xml(open("tests/wsdl_files/soap-enc.xsd").read().encode("utf-8")),
     )
     return transport
 
@@ -322,7 +322,7 @@ def test_soap_array_parse_remote_ns():
     transport = DummyTransport()
     transport.bind(
         "http://schemas.xmlsoap.org/soap/encoding/",
-        load_xml(io.open("tests/wsdl_files/soap-enc.xsd", "r").read().encode("utf-8")),
+        load_xml(open("tests/wsdl_files/soap-enc.xsd").read().encode("utf-8")),
     )
 
     schema = xsd.Schema(
@@ -392,7 +392,7 @@ def test_wsdl_array_type():
     transport = DummyTransport()
     transport.bind(
         "http://schemas.xmlsoap.org/soap/encoding/",
-        load_xml(io.open("tests/wsdl_files/soap-enc.xsd", "r").read().encode("utf-8")),
+        load_xml(open("tests/wsdl_files/soap-enc.xsd").read().encode("utf-8")),
     )
 
     schema = xsd.Schema(
@@ -466,7 +466,7 @@ def test_soap_array_parse():
     transport = DummyTransport()
     transport.bind(
         "http://schemas.xmlsoap.org/soap/encoding/",
-        load_xml(io.open("tests/wsdl_files/soap-enc.xsd", "r").read().encode("utf-8")),
+        load_xml(open("tests/wsdl_files/soap-enc.xsd").read().encode("utf-8")),
     )
 
     schema = xsd.Schema(

--- a/tests/test_wsdl_arrays.py
+++ b/tests/test_wsdl_arrays.py
@@ -1,4 +1,3 @@
-import io
 
 import pytest
 from lxml import etree

--- a/tests/test_wsdl_messages_rpc.py
+++ b/tests/test_wsdl_messages_rpc.py
@@ -216,7 +216,7 @@ def test_wsdl_array_of_simple_types():
     transport = DummyTransport()
     transport.bind(
         "http://schemas.xmlsoap.org/soap/encoding/",
-        load_xml(io.open("tests/wsdl_files/soap-enc.xsd", "r").read().encode("utf-8")),
+        load_xml(open("tests/wsdl_files/soap-enc.xsd").read().encode("utf-8")),
     )
     root = wsdl.Document(wsdl_content, transport)
 

--- a/tests/test_wsdl_messages_rpc.py
+++ b/tests/test_wsdl_messages_rpc.py
@@ -1,4 +1,3 @@
-import io
 from io import StringIO
 
 from tests.utils import DummyTransport, assert_nodes_equal, load_xml

--- a/tests/test_wsdl_soap.py
+++ b/tests/test_wsdl_soap.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import platform
 
 import pytest

--- a/tests/test_wsse_signature.py
+++ b/tests/test_wsse_signature.py
@@ -2,7 +2,6 @@ import os
 import sys
 
 import pytest
-from lxml import etree
 from lxml.etree import QName
 
 from tests.utils import load_xml

--- a/tests/test_xsd_extension.py
+++ b/tests/test_xsd_extension.py
@@ -437,7 +437,7 @@ def test_issue_221():
     transport.bind(
         "https://www.w3.org/TR/xmldsig-core/xmldsig-core-schema.xsd",
         load_xml(
-            io.open("tests/wsdl_files/xmldsig-core-schema.xsd", "r")
+            open("tests/wsdl_files/xmldsig-core-schema.xsd")
             .read()
             .encode("utf-8")
         ),

--- a/tests/test_xsd_extension.py
+++ b/tests/test_xsd_extension.py
@@ -1,5 +1,4 @@
 import datetime
-import io
 
 from lxml import etree
 

--- a/tests/test_xsd_schemas.py
+++ b/tests/test_xsd_schemas.py
@@ -1021,7 +1021,7 @@ def test_xml_namespace():
 
 
 def test_auto_import_known_schema():
-    content = io.open("tests/wsdl_files/soap-enc.xsd", "rb").read()
+    content = open("tests/wsdl_files/soap-enc.xsd", "rb").read()
 
     transport = DummyTransport()
     transport.bind("http://schemas.xmlsoap.org/soap/encoding/", content)

--- a/tests/test_xsd_schemas.py
+++ b/tests/test_xsd_schemas.py
@@ -1,4 +1,3 @@
-import io
 
 import pytest
 from lxml import etree

--- a/tests/test_xsd_types.py
+++ b/tests/test_xsd_types.py
@@ -1,4 +1,4 @@
-from datetime import datetime, time
+from datetime import datetime
 from decimal import Decimal
 
 import isodate

--- a/tests/test_xsd_union.py
+++ b/tests/test_xsd_union.py
@@ -47,7 +47,7 @@ def test_union_same_types():
 def test_union_mixed():
     schema = xsd.Schema(
         load_xml(
-            """
+            r"""
         <?xml version="1.0"?>
         <xsd:schema
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed 27 Jun 2023.
Filter all code over `pyupgracde --py38-plus`.