### PR TITLE
[FIX] No visitor defined for '{http://www.w3.org/2001/XMLSchema}notation

### DIFF
--- a/src/zeep/xsd/visitor.py
+++ b/src/zeep/xsd/visitor.py
@@ -37,7 +37,7 @@ class tags:
     attributeGroup = xsd_ns("attributeGroup")
     restriction = xsd_ns("restriction")
     extension = xsd_ns("extension")
-    notation = xsd_ns("notations")
+    notation = xsd_ns("notation")
 
 
 class SchemaVisitor:


### PR DESCRIPTION
reintroduce the "notation" tag because '{http://www.w3.org/2001/XMLSchema}notations' does not exist

fixes #1185