### PR TITLE
x509 Feat and Fix - fixes multiple wsse, add option do disable response verification, and use another cert  for verify

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -51,5 +51,5 @@ Contributors
 * Zoltan Benedek
 * Øyvind Heddeland Instefjord
 * Gil Obradors
-
+* Pol Sanlorenzo
 

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -50,5 +50,6 @@ Contributors
 * Raymond Piller
 * Zoltan Benedek
 * Øyvind Heddeland Instefjord
+* Gil Obradors
 
 

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -50,5 +50,5 @@ Contributors
 * Raymond Piller
 * Zoltan Benedek
 * Øyvind Heddeland Instefjord
-* Pol Sanlorenzo
+
 

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -52,4 +52,4 @@ Contributors
 * Øyvind Heddeland Instefjord
 * Gil Obradors
 * Pol Sanlorenzo
-
+* Caio Salgado

--- a/docs/wsse.rst
+++ b/docs/wsse.rst
@@ -37,6 +37,11 @@ Example usage A::
     ...         optional_password))
 
 
+To skip response signature verification set `verify_reply_signature=False`
+
+To configure different certificate for response verify proces set `response_key_file` or
+and `response_certfile`.
+
 .. _xmlsec: https://pypi.python.org/pypi/xmlsec
 .. _README: https://github.com/mehcode/python-xmlsec
 

--- a/docs/wsse.rst
+++ b/docs/wsse.rst
@@ -10,7 +10,7 @@ The UsernameToken supports both the passwordText and passwordDigest methods::
     >>> from zeep import Client
     >>> from zeep.wsse.username import UsernameToken
     >>> client = Client(
-    ...     'http://www.webservicex.net/ConvertSpeed.asmx?WSDL', 
+    ...     'http://www.webservicex.net/ConvertSpeed.asmx?WSDL',
     ...     wsse=UsernameToken('username', 'password'))
 
 To use the passwordDigest method you need to supply `use_digest=True` to the
@@ -21,26 +21,38 @@ Signature (x509)
 ----------------
 
 To use the wsse.Signature() plugin you will need to install the `xmlsec`_
-module. See the `README`_ for xmlsec for the required dependencies on your 
+module. See the `README`_ for xmlsec for the required dependencies on your
 platform.
 
 To append the security token as `BinarySecurityToken`, you can use wsse.BinarySignature() plugin.
+
+To skip response signature verification set `verify_reply_signature=False`
+
+To configure different certificate for response verify process, set `response_key_file` or
+and `response_certfile`.
 
 Example usage A::
 
     >>> from zeep import Client
     >>> from zeep.wsse.signature import Signature
     >>> client = Client(
-    ...     'http://www.webservicex.net/ConvertSpeed.asmx?WSDL', 
+    ...     'http://www.webservicex.net/ConvertSpeed.asmx?WSDL',
     ...     wsse=Signature(
-    ...         private_key_filename, public_key_filename, 
+    ...         private_key_filename, public_key_filename,
     ...         optional_password))
 
+Example usage B::
 
-To skip response signature verification set `verify_reply_signature=False`
-
-To configure different certificate for response verify proces set `response_key_file` or
-and `response_certfile`.
+    >>> from zeep import Client
+    >>> from zeep.wsse.signature import Signature
+    >>> from zeep.transports import Transport
+    >>> from requests import Session
+    >>> session = Session()
+    >>> session.cert = '/path/to/ssl.pem'
+    >>> transport = Transport(session=session)
+    >>> client = Client(
+    ...     'http://www.webservicex.net/ConvertSpeed.asmx?WSDL',
+    ...     transport=transport)
 
 .. _xmlsec: https://pypi.python.org/pypi/xmlsec
 .. _README: https://github.com/mehcode/python-xmlsec

--- a/docs/wsse.rst
+++ b/docs/wsse.rst
@@ -36,19 +36,7 @@ Example usage A::
     ...         private_key_filename, public_key_filename, 
     ...         optional_password))
 
-Example usage B::
 
-    >>> from zeep import Client
-    >>> from zeep.wsse.signature import Signature
-    >>> from zeep.transports import Transport
-    >>> from requests import Session
-    >>> session = Session()
-    >>> session.cert = '/path/to/ssl.pem'
-    >>> transport = Transport(session=session)
-    >>> client = Client(
-    ...     'http://www.webservicex.net/ConvertSpeed.asmx?WSDL',
-    ...     transport=transport)
-    
 .. _xmlsec: https://pypi.python.org/pypi/xmlsec
 .. _README: https://github.com/mehcode/python-xmlsec
 

--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 import logging
 import typing
 
@@ -93,7 +94,7 @@ class SoapBinding(Binding):
 
             # Apply WSSE
             if client.wsse:
-                if isinstance(client.wsse, list):
+                if isinstance(client.wsse, Sequence):
                     for wsse in client.wsse:
                         envelope, http_headers = wsse.apply(envelope, http_headers)
                 else:
@@ -216,7 +217,7 @@ class SoapBinding(Binding):
                 message_pack = None
 
         if client.wsse:
-            if isinstance(client.wsse, list):
+            if isinstance(client.wsse, Sequence):
                 for wsse in client.wsse:
                     wsse.verify(doc)
             else:

--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -216,7 +216,11 @@ class SoapBinding(Binding):
                 message_pack = None
 
         if client.wsse:
-            client.wsse.verify(doc)
+            if isinstance(client.wsse, list):
+                for wsse in client.wsse:
+                    wsse.verify(doc)
+            else:
+                client.wsse.verify(doc)
 
         doc, http_headers = plugins.apply_ingress(
             client, doc, response.headers, operation

--- a/src/zeep/wsse/signature.py
+++ b/src/zeep/wsse/signature.py
@@ -52,6 +52,8 @@ class MemorySignature:
         password=None,
         signature_method=None,
         digest_method=None,
+        verify_reply_signature=True,
+        response_cert_data=None
     ):
         check_xmlsec_import()
 
@@ -60,6 +62,8 @@ class MemorySignature:
         self.password = password
         self.digest_method = digest_method
         self.signature_method = signature_method
+        self.verify_reply_signature = verify_reply_signature
+        self.response_cert_data= response_cert_data
 
     def apply(self, envelope, headers):
         key = _make_sign_key(self.key_data, self.cert_data, self.password)
@@ -69,7 +73,10 @@ class MemorySignature:
         return envelope, headers
 
     def verify(self, envelope):
-        key = _make_verify_key(self.cert_data)
+        if not self.verify_reply_signature:
+            return envelope
+        key = _make_verify_key(self.cert_data if not self.response_cert_data else
+                               self.response_cert_data)
         _verify_envelope_with_key(envelope, key)
         return envelope
 
@@ -84,6 +91,8 @@ class Signature(MemorySignature):
         password=None,
         signature_method=None,
         digest_method=None,
+        verify_reply_signature=True,
+        response_certfile=None
     ):
         super().__init__(
             _read_file(key_file),
@@ -91,6 +100,8 @@ class Signature(MemorySignature):
             password,
             signature_method,
             digest_method,
+            verify_reply_signature,
+            _read_file(response_certfile) if response_certfile else None
         )
 
 

--- a/src/zeep/wsse/signature.py
+++ b/src/zeep/wsse/signature.py
@@ -360,7 +360,7 @@ def _sign_node(ctx, signature, target, digest_method=None):
     """
 
     # Ensure the target node has a wsu:Id attribute and get its value.
-    node_id = ensure_id(target)
+    ensure_id(target)
 
     # Unlike HTML, XML doesn't have a single standardized Id. WSSE suggests the
     # use of the wsu:Id attribute for this purpose, but XMLSec doesn't
@@ -370,10 +370,10 @@ def _sign_node(ctx, signature, target, digest_method=None):
 
     # Add reference to signature with URI attribute pointing to that ID.
     ref = xmlsec.template.add_reference(
-        signature, digest_method or xmlsec.Transform.SHA1, uri="#" + node_id
+        signature, digest_method or xmlsec.Transform.SHA1, uri=""
     )
     # This is an XML normalization transform which will be performed on the
     # target node contents before signing. This ensures that changes to
     # irrelevant whitespace, attribute ordering, etc won't invalidate the
     # signature.
-    xmlsec.template.add_transform(ref, xmlsec.Transform.EXCL_C14N)
+    xmlsec.template.add_transform(ref, xmlsec.Transform.ENVELOPED)

--- a/src/zeep/wsse/signature.py
+++ b/src/zeep/wsse/signature.py
@@ -8,6 +8,7 @@ admittedly painful, will likely assist in understanding the code in this
 module.
 
 """
+
 from lxml import etree
 from lxml.etree import QName
 
@@ -53,7 +54,7 @@ class MemorySignature:
         signature_method=None,
         digest_method=None,
         verify_reply_signature=True,
-        response_cert_data=None
+        response_cert_data=None,
     ):
         check_xmlsec_import()
 
@@ -63,7 +64,7 @@ class MemorySignature:
         self.digest_method = digest_method
         self.signature_method = signature_method
         self.verify_reply_signature = verify_reply_signature
-        self.response_cert_data= response_cert_data
+        self.response_cert_data = response_cert_data
 
     def apply(self, envelope, headers):
         key = _make_sign_key(self.key_data, self.cert_data, self.password)
@@ -75,8 +76,9 @@ class MemorySignature:
     def verify(self, envelope):
         if not self.verify_reply_signature:
             return envelope
-        key = _make_verify_key(self.cert_data if not self.response_cert_data else
-                               self.response_cert_data)
+        key = _make_verify_key(
+            self.cert_data if not self.response_cert_data else self.response_cert_data
+        )
         _verify_envelope_with_key(envelope, key)
         return envelope
 
@@ -92,7 +94,7 @@ class Signature(MemorySignature):
         signature_method=None,
         digest_method=None,
         verify_reply_signature=True,
-        response_certfile=None
+        response_certfile=None,
     ):
         super().__init__(
             _read_file(key_file),
@@ -101,7 +103,7 @@ class Signature(MemorySignature):
             signature_method,
             digest_method,
             verify_reply_signature,
-            _read_file(response_certfile) if response_certfile else None
+            _read_file(response_certfile) if response_certfile else None,
         )
 
 


### PR DESCRIPTION
Still need to add tests, and document `wsse.signature._sign_node` But this changes were necessary for zeep to correctly work with x509 signature + username in some web services.


fixes:
 * #953
 * kind of #1084
 * use the patch from #1077 


adds features:
 * option to not verify response #1118 