### PR TITLE
Use f-strings in most places

### DIFF
--- a/src/zeep/cache.py
+++ b/src/zeep/cache.py
@@ -60,7 +60,7 @@ class VersionedCacheBase(Base):
         assert (
             getattr(self, "_version", None) is not None
         ), "A version must be provided in order to use the VersionedCacheBase backend."
-        prefix = "$ZEEP:%s$" % self._version
+        prefix = f"$ZEEP:{self._version}$"
         return bytes(prefix.encode("ascii"))
 
 
@@ -77,7 +77,7 @@ class InMemoryCache(Base):
         logger.debug("Caching contents of %s", url)
         if not isinstance(content, (str, bytes)):
             raise TypeError(
-                "a bytes-like object is required, not {}".format(type(content).__name__)
+                f"a bytes-like object is required, not {type(content).__name__}"
             )
         self._cache[url] = (datetime.datetime.now(datetime.timezone.utc), content)
 

--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class Factory:
     def __init__(self, types, kind, namespace):
-        self._method = getattr(types, "get_%s" % kind)
+        self._method = getattr(types, f"get_{kind}")
 
         if namespace in types.namespaces:
             self._ns = namespace
@@ -137,7 +137,7 @@ class Client:
         except KeyError:
             raise ValueError(
                 "No binding found with the given QName. Available bindings "
-                "are: %s" % (", ".join(self.wsdl.bindings.keys()))
+                f"are: {', '.join(self.wsdl.bindings.keys())}"
             )
         return ServiceProxy(self, binding, address=address)
 

--- a/src/zeep/exceptions.py
+++ b/src/zeep/exceptions.py
@@ -4,7 +4,7 @@ class Error(Exception):
         self.message = message
 
     def __repr__(self):
-        return "%s(%r)" % (self.__class__.__name__, self.message)
+        return f"{self.__class__.__name__}({self.message!r})"
 
 
 class XMLSyntaxError(Error):
@@ -22,9 +22,9 @@ class XMLParseError(Error):
     def __str__(self):
         location = None
         if self.filename and self.sourceline:
-            location = "%s:%s" % (self.filename, self.sourceline)
+            location = f"{self.filename}:{self.sourceline}"
         if location:
-            return "%s (%s)" % (self.message, location)
+            return f"{self.message} ({location})"
         return self.message
 
 
@@ -77,7 +77,7 @@ class ValidationError(Error):
     def __str__(self):
         if self.path:
             path = ".".join(str(x) for x in self.path)
-            return "%s (%s)" % (self.message, path)
+            return f"{self.message} ({path})"
         return self.message
 
 

--- a/src/zeep/loader.py
+++ b/src/zeep/loader.py
@@ -64,7 +64,7 @@ def parse_xml(content: str, transport, base_url=None, settings=None):
         return elementtree
     except etree.XMLSyntaxError as exc:
         raise XMLSyntaxError(
-            "Invalid XML content received (%s)" % exc.msg, content=content
+            f"Invalid XML content received ({exc.msg})", content=content
         )
 
 

--- a/src/zeep/proxy.py
+++ b/src/zeep/proxy.py
@@ -96,7 +96,7 @@ class ServiceProxy:
         try:
             return self._operations[key]
         except KeyError:
-            raise AttributeError("Service has no operation %r" % key)
+            raise AttributeError(f"Service has no operation {key!r}")
 
     def __iter__(self):
         """Return iterator over the services and their callables."""

--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -40,9 +40,7 @@ class Transport:
         self._close_session = not session
         self.session = session or requests.Session()
         self.session.mount("file://", FileAdapter())
-        self.session.headers["User-Agent"] = "Zeep/%s (www.python-zeep.org)" % (
-            get_version()
-        )
+        self.session.headers["User-Agent"] = f"Zeep/{get_version()} (www.python-zeep.org)"
 
     def get(self, address, params, headers):
         """Proxy to requests.get()
@@ -196,10 +194,10 @@ class AsyncTransport(Transport):
         self.logger = logging.getLogger(__name__)
 
         self.wsdl_client.headers = {
-            "User-Agent": "Zeep/%s (www.python-zeep.org)" % (get_version())
+            "User-Agent": f"Zeep/{get_version()} (www.python-zeep.org)"
         }
         self.client.headers = {
-            "User-Agent": "Zeep/%s (www.python-zeep.org)" % (get_version())
+            "User-Agent": f"Zeep/{get_version()} (www.python-zeep.org)"
         }
 
     async def aclose(self):

--- a/src/zeep/utils.py
+++ b/src/zeep/utils.py
@@ -33,7 +33,7 @@ def as_qname(value: str, nsmap, target_namespace=None) -> etree.QName:
             namespace = nsmap.get(prefix)
 
         if not namespace:
-            raise XMLParseError("No namespace defined for %r (%r)" % (prefix, value))
+            raise XMLParseError(f"No namespace defined for {prefix!r} ({value!r})")
 
         # Workaround for https://github.com/mvantellingen/python-zeep/issues/349
         if not local:

--- a/src/zeep/wsdl/attachments.py
+++ b/src/zeep/wsdl/attachments.py
@@ -15,9 +15,8 @@ class MessagePack:
         self._parts = parts
 
     def __repr__(self):
-        return "<MessagePack(attachments=[%s])>" % (
-            ", ".join(repr(a) for a in self.attachments)
-        )
+        joined_attachments = ", ".join(repr(a) for a in self.attachments)
+        return f"<MessagePack(attachments=[{joined_attachments}])>"
 
     @property
     def root(self):
@@ -60,7 +59,7 @@ class Attachment:
         self._part = part
 
     def __repr__(self):
-        return "<Attachment(%r, %r)>" % (self.content_id, self.content_type)
+        return f"<Attachment({self.content_id!r}, {self.content_type!r})>"
 
     @cached_property
     def content(self):

--- a/src/zeep/wsdl/bindings/http.py
+++ b/src/zeep/wsdl/bindings/http.py
@@ -61,7 +61,7 @@ class HttpPostBinding(HttpBinding):
         """Called from the service"""
         operation_obj = self.get(operation)
         if not operation_obj:
-            raise ValueError("Operation %r not found" % operation)
+            raise ValueError(f"Operation {operation!r} not found")
 
         serialized = operation_obj.create(*args, **kwargs)
 
@@ -89,7 +89,7 @@ class HttpGetBinding(HttpBinding):
         """Called from the service"""
         operation_obj = self.get(operation)
         if not operation_obj:
-            raise ValueError("Operation %r not found" % operation)
+            raise ValueError(f"Operation {operation!r} not found")
 
         serialized = operation_obj.create(*args, **kwargs)
 

--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -67,7 +67,7 @@ class SoapBinding(Binding):
         """
         operation_obj = self.get(operation)
         if not operation_obj:
-            raise ValueError("Operation %r not found" % operation)
+            raise ValueError(f"Operation {operation!r} not found")
 
         # Create the SOAP envelope
         serialized = operation_obj.create(*args, **kwargs)
@@ -179,8 +179,7 @@ class SoapBinding(Binding):
 
         elif response.status_code != 200 and not response.content:
             raise TransportError(
-                "Server returned HTTP status %d (no content available)"
-                % response.status_code,
+                f"Server returned HTTP status {response.status_code} (no content available)",
                 status_code=response.status_code,
             )
 
@@ -204,8 +203,10 @@ class SoapBinding(Binding):
             doc = parse_xml(content, self.transport, settings=client.settings)
         except XMLSyntaxError as exc:
             raise TransportError(
-                "Server returned response (%s) with invalid XML: %s.\nContent: %r"
-                % (response.status_code, exc, response.content),
+                (
+                    f"Server returned response ({response.status_code}) with invalid XML: {exc}."
+                    f"\nContent: {response.content!r}"
+                ),
                 status_code=response.status_code,
                 content=response.content,
             )
@@ -290,8 +291,7 @@ class SoapBinding(Binding):
 
         if transport not in supported_transports:
             raise NotImplementedError(
-                "The binding transport %s is not supported (only soap/http)"
-                % (transport)
+                f"The binding transport {transport} is not supported (only soap/http)"
             )
         default_style = soap_node.get("style", "document")
 
@@ -401,7 +401,7 @@ class Soap12Binding(SoapBinding):
             [
                 "application/soap+xml",
                 "charset=utf-8",
-                'action="%s"' % operation.soapaction,
+                f'action="{operation.soapaction}"',
             ]
         )
 

--- a/src/zeep/wsdl/definitions.py
+++ b/src/zeep/wsdl/definitions.py
@@ -50,7 +50,7 @@ class AbstractMessage:
         self.parts = OrderedDict()
 
     def __repr__(self):
-        return "<%s(name=%r)>" % (self.__class__.__name__, self.name.text)
+        return f"<{self.__class__.__name__}(name={self.name.text!r})>"
 
     def resolve(self, definitions):
         pass
@@ -99,7 +99,7 @@ class PortType:
         self.operations = operations
 
     def __repr__(self):
-        return "<%s(name=%r)>" % (self.__class__.__name__, self.name.text)
+        return f"<{self.__class__.__name__}(name={self.name.text!r})>"
 
     def resolve(self, definitions):
         pass
@@ -152,14 +152,10 @@ class Binding:
         self._operations[operation.name] = operation
 
     def __str__(self):
-        return "%s: %s" % (self.__class__.__name__, self.name.text)
+        return f"{self.__class__.__name__}: {self.name.text}"
 
     def __repr__(self):
-        return "<%s(name=%r, port_type=%r)>" % (
-            self.__class__.__name__,
-            self.name.text,
-            self.port_type,
-        )
+        return f"<{self.__class__.__name__}(name={self.name.text!r}, port_type={self.port_type!r})>"
 
     def all(self):
         return self._operations
@@ -168,7 +164,7 @@ class Binding:
         try:
             return self._operations[key]
         except KeyError:
-            raise ValueError("No such operation %r on %s" % (key, self.name))
+            raise ValueError(f"No such operation {key!r} on {self.name}")
 
     @classmethod
     def match(cls, node):
@@ -200,24 +196,22 @@ class Operation:
             self.abstract = self.binding.port_type.operations[self.name]
         except KeyError:
             raise IncompleteOperation(
-                "The wsdl:operation %r was not found in the wsdl:portType %r"
-                % (self.name, self.binding.port_type.name.text)
+                (
+                    f"The wsdl:operation {self.name!r} was not found in the"
+                    f" wsdl:portType {self.binding.port_type.name.text!r}"
+                )
             )
 
     def __repr__(self):
-        return "<%s(name=%r, style=%r)>" % (
-            self.__class__.__name__,
-            self.name,
-            self.style,
-        )
+        return f"<{self.__class__.__name__}(name={self.name!r}, style={self.style!r})>"
 
     def __str__(self):
         if not self.input:
-            return "%s(missing input message)" % (self.name)
+            return f"{self.name}(missing input message)"
 
-        retval = "%s(%s)" % (self.name, self.input.signature())
+        retval = f"{self.name}({self.input.signature()})"
         if self.output:
-            retval += " -> %s" % (self.output.signature(as_output=True))
+            retval += f" -> {self.output.signature(as_output=True)}"
         return retval
 
     def create(self, *args, **kwargs):
@@ -268,15 +262,10 @@ class Port:
         self.binding_options = {}
 
     def __repr__(self):
-        return "<%s(name=%r, binding=%r, %r)>" % (
-            self.__class__.__name__,
-            self.name,
-            self.binding,
-            self.binding_options,
-        )
+        return f"<{self.__class__.__name__}(name={self.name!r}, binding={self.binding!r}, {self.binding_options!r})>"
 
     def __str__(self):
-        return "Port: %s (%s)" % (self.name, self.binding)
+        return f"Port: {self.name} ({self.binding})"
 
     def resolve(self, definitions):
         if self._resolve_context is None:
@@ -310,14 +299,10 @@ class Service:
         self._is_resolved = False
 
     def __str__(self):
-        return "Service: %s" % self.name
+        return f"Service: {self.name}"
 
     def __repr__(self):
-        return "<%s(name=%r, ports=%r)>" % (
-            self.__class__.__name__,
-            self.name,
-            self.ports,
-        )
+        return f"<{self.__class__.__name__}(name={self.name!r}, ports={self.ports!r})>"
 
     def resolve(self, definitions):
         if self._is_resolved:

--- a/src/zeep/wsdl/messages/http.py
+++ b/src/zeep/wsdl/messages/http.py
@@ -86,7 +86,7 @@ class UrlReplacement(HttpMessage):
 
         path = self.operation.location
         for key, value in params.items():
-            path = path.replace("(%s)" % key, value if value is not None else "")
+            path = path.replace(f"({key})", value if value is not None else "")
         return SerializedMessage(path=path, headers=headers, content="")
 
     @classmethod

--- a/src/zeep/wsdl/messages/mime.py
+++ b/src/zeep/wsdl/messages/mime.py
@@ -46,8 +46,7 @@ class MimeMessage(ConcreteMessage):
                 message = list(self.abstract.parts.values())[0]
             else:
                 raise ValueError(
-                    "Multiple parts for message %r while no matching part found"
-                    % self.part_name
+                    f"Multiple parts for message {self.part_name!r} while no matching part found"
                 )
 
             if message.element:

--- a/src/zeep/wsdl/messages/multiref.py
+++ b/src/zeep/wsdl/messages/multiref.py
@@ -122,7 +122,7 @@ def _prefix_node(node):
             namespace, localname = match.groups()
 
             if namespace in reverse_nsmap:
-                value = "%s:%s" % (reverse_nsmap.get(namespace), localname)
+                value = f"{reverse_nsmap.get(namespace)}:{localname}"
                 node.set(key, value)
 
 

--- a/src/zeep/wsdl/messages/soap.py
+++ b/src/zeep/wsdl/messages/soap.py
@@ -87,7 +87,7 @@ class SoapMessage(ConcreteMessage):
         # now.
         headers = {
             "SOAPAction": (
-                '"%s"' % self.operation.soapaction
+                f'"{self.operation.soapaction}"'
                 if self.operation.soapaction
                 else '""'
             )

--- a/src/zeep/wsdl/messages/xop.py
+++ b/src/zeep/wsdl/messages/xop.py
@@ -14,11 +14,11 @@ def process_xop(document, message_pack):
         href = xop_node.get("href")
         if href.startswith("cid:"):
             # URL can be encoded. RFC2392
-            href = "<%s>" % unquote(href[4:])
+            href = f"<{unquote(href[4:])}>"
 
         value = message_pack.get_by_content_id(href)
         if not value:
-            raise ValueError("No part found for: %r" % xop_node.get("href"))
+            raise ValueError(f"No part found for: {xop_node.get('href')!r}")
         num_replaced += 1
 
         xop_parent = xop_node.getparent()

--- a/src/zeep/wsdl/parse.py
+++ b/src/zeep/wsdl/parse.py
@@ -60,10 +60,9 @@ def parse_abstract_message(
         except (NamespaceError, LookupError):
             raise IncompleteMessage(
                 (
-                    "The wsdl:message for %r contains an invalid part (%r): "
+                    f"The wsdl:message for {message_name.text!r} contains an invalid part ({part_name!r}): "
                     "invalid xsd type or elements"
                 )
-                % (message_name.text, part_name)
             )
 
         message_part = definitions.MessagePart(part_element, part_type)
@@ -116,7 +115,7 @@ def parse_abstract_operation(
 
         if not param_msg:
             raise IncompleteMessage(
-                "Operation/%s element is missing required name attribute" % tag_name
+                f"Operation/{tag_name} element is missing required name attribute"
             )
 
         try:

--- a/src/zeep/wsdl/wsdl.py
+++ b/src/zeep/wsdl/wsdl.py
@@ -98,13 +98,13 @@ class Document:
         self.services = root_definitions.services
 
     def __repr__(self):
-        return "<WSDL(location=%r)>" % self.location
+        return f"<WSDL(location={self.location!r})>"
 
     def dump(self):
         print("")
         print("Prefixes:")
         for prefix, namespace in self.types.prefix_map.items():
-            print(" " * 4, "%s: %s" % (prefix, namespace))
+            print(" " * 4, f"{prefix}: {namespace}")
 
         print("")
         print("Global elements:")
@@ -135,7 +135,7 @@ class Document:
                 )
 
                 for operation in operations:
-                    print("%s%s" % (" " * 12, str(operation)))
+                    print(" " * 12, str(operation))
                 print("")
 
     def _get_xml_document(self, location: typing.IO) -> etree._Element:
@@ -196,7 +196,7 @@ class Definition:
         self.services = self.parse_service(doc)
 
     def __repr__(self):
-        return "<%s(location=%r)>" % (self.__class__.__name__, self.location)
+        return f"<{self.__class__.__name__}(location={self.location!r})>"
 
     def get(self, name, key, _processed=None):
         container = getattr(self, name)
@@ -223,7 +223,7 @@ class Definition:
                     except IndexError:
                         pass
 
-        raise IndexError("No definition %r in %r found" % (key, name))
+        raise IndexError(f"No definition {key!r} in {name!r} found")
 
     def resolve_imports(self) -> None:
         """Resolve all root elements (types, messages, etc)."""

--- a/src/zeep/wsse/signature.py
+++ b/src/zeep/wsse/signature.py
@@ -321,7 +321,7 @@ def _verify_envelope_with_key(envelope, key):
         # Get the reference URI and cut off the initial '#'
         referenced_id = ref.get("URI")[1:]
         referenced = envelope.xpath(
-            "//*[@wsu:Id='%s']" % referenced_id, namespaces={"wsu": ns.WSU}
+            f"//*[@wsu:Id='{referenced_id}']", namespaces={"wsu": ns.WSU}
         )[0]
         ctx.register_id(referenced, "Id", ns.WSU)
 

--- a/src/zeep/wsse/username.py
+++ b/src/zeep/wsse/username.py
@@ -95,7 +95,7 @@ class UsernameToken:
     def _create_password_text(self):
         return [
             utils.WSSE.Password(
-                self.password, Type="%s#PasswordText" % self.username_token_profile_ns
+                self.password, Type=f"{self.username_token_profile_ns}#PasswordText"
             )
         ]
 
@@ -127,11 +127,11 @@ class UsernameToken:
 
         return [
             utils.WSSE.Password(
-                digest, Type="%s#PasswordDigest" % self.username_token_profile_ns
+                digest, Type=f"{self.username_token_profile_ns}#PasswordDigest"
             ),
             utils.WSSE.Nonce(
                 base64.b64encode(nonce).decode("utf-8"),
-                EncodingType="%s#Base64Binary" % self.soap_message_secutity_ns,
+                EncodingType=f"{self.soap_message_secutity_ns}#Base64Binary",
             ),
             utils.WSU.Created(timestamp),
         ]

--- a/src/zeep/wsse/utils.py
+++ b/src/zeep/wsse/utils.py
@@ -37,7 +37,7 @@ def get_timestamp(timestamp=None, zulu_timestamp=None):
 
 
 def get_unique_id():
-    return "id-{0}".format(uuid4())
+    return f"id-{uuid4()}"
 
 
 def ensure_id(node):

--- a/src/zeep/xsd/elements/any.py
+++ b/src/zeep/xsd/elements/any.py
@@ -44,7 +44,7 @@ class Any(Base):
         return any_object
 
     def __repr__(self):
-        return "<%s(name=%r)>" % (self.__class__.__name__, self.name)
+        return f"<{self.__class__.__name__}(name={self.name!r})>"
 
     def accept(self, value):
         return True
@@ -170,7 +170,7 @@ class Any(Base):
             # Validate bounds
             if len(value) < self.min_occurs:
                 raise exceptions.ValidationError(
-                    "Expected at least %d items (minOccurs check)" % self.min_occurs
+                    f"Expected at least {self.min_occurs} items (minOccurs check)"
                 )
             if (
                 self.max_occurs != "unbounded"
@@ -178,7 +178,7 @@ class Any(Base):
                 and len(value) > self.max_occurs
             ):
                 raise exceptions.ValidationError(
-                    "Expected at most %d items (maxOccurs check)" % self.min_occurs
+                    f"Expected at most {self.min_occurs} items (maxOccurs check)"
                 )
 
             for val in value:
@@ -203,15 +203,13 @@ class Any(Base):
         if value in (None, NotSet):
             if not self.is_optional:
                 raise exceptions.ValidationError(
-                    "Missing element %s" % (self.name), path=render_path
+                    f"Missing element {self.name}", path=render_path
                 )
 
         elif not isinstance(value, tuple(expected_types)):
-            type_names = ["%s.%s" % (t.__module__, t.__name__) for t in expected_types]
-            err_message = "Any element received object of type %r, expected %s" % (
-                type(value).__name__,
-                " or ".join(type_names),
-            )
+            type_names = [f"{t.__module__}.{t.__name__}" for t in expected_types]
+            joined_type_names = " or ".join(type_names)
+            err_message = f"Any element received object of type {type(value).__name__!r}, expected {joined_type_names}"
 
             raise TypeError(
                 "\n".join(
@@ -233,7 +231,7 @@ class Any(Base):
             base = "ANY"
 
         if self.accepts_multiple:
-            return "%s[]" % base
+            return f"{base}[]"
         return base
 
 

--- a/src/zeep/xsd/elements/attribute.py
+++ b/src/zeep/xsd/elements/attribute.py
@@ -38,7 +38,7 @@ class Attribute(Element):
             self.type.validate(value, required=self.required)
         except exceptions.ValidationError as exc:
             raise exceptions.ValidationError(
-                "The attribute %s is not valid: %s" % (self.qname, exc.message),
+                f"The attribute {self.qname} is not valid: {exc.message}",
                 path=render_path,
             )
 

--- a/src/zeep/xsd/elements/element.py
+++ b/src/zeep/xsd/elements/element.py
@@ -49,10 +49,10 @@ class Element(Base):
     def __str__(self):
         if self.type:
             if self.type.is_global:
-                return "%s(%s)" % (self.name, self.type.qname)
+                return f"{self.name}({self.type.qname})"
             else:
-                return "%s(%s)" % (self.name, self.type.signature())
-        return "%s()" % self.name
+                return f"{self.name}({self.type.signature()})"
+        return f"{self.name}()"
 
     def __call__(self, *args, **kwargs):
         instance = self.type(*args, **kwargs)
@@ -61,11 +61,7 @@ class Element(Base):
         return instance
 
     def __repr__(self):
-        return "<%s(name=%r, type=%r)>" % (
-            self.__class__.__name__,
-            self.name,
-            self.type,
-        )
+        return f"<{self.__class__.__name__}(name={self.name!r}, type={self.type!r})>"
 
     def __eq__(self, other):
         return (
@@ -204,8 +200,7 @@ class Element(Base):
                 # not optional then throw an error
                 if num_matches == 0 and not self.is_optional:
                     raise UnexpectedElementError(
-                        "Unexpected element %r, expected %r"
-                        % (element_tag.text, self.qname.text)
+                        f"Unexpected element {element_tag.text!r}, expected {self.qname.text!r}"
                     )
                 break
 
@@ -262,8 +257,7 @@ class Element(Base):
             # Validate bounds
             if len(value) < self.min_occurs:
                 raise exceptions.ValidationError(
-                    "Expected at least %d items (minOccurs check) %d items found."
-                    % (self.min_occurs, len(value)),
+                    f"Expected at least {self.min_occurs} items (minOccurs check) {len(value)} items found.",
                     path=render_path,
                 )
             elif (
@@ -272,8 +266,7 @@ class Element(Base):
                 and len(value) > self.max_occurs
             ):
                 raise exceptions.ValidationError(
-                    "Expected at most %d items (maxOccurs check) %d items found."
-                    % (self.max_occurs, len(value)),
+                    f"Expected at most {self.max_occurs} items (maxOccurs check) {len(value)} items found.",
                     path=render_path,
                 )
 
@@ -282,7 +275,7 @@ class Element(Base):
         else:
             if not self.is_optional and not self.nillable and value in (None, NotSet):
                 raise exceptions.ValidationError(
-                    "Missing element %s" % (self.name), path=render_path
+                    f"Missing element {self.name}", path=render_path
                 )
 
             self._validate_item(value, render_path)
@@ -295,7 +288,7 @@ class Element(Base):
             self.type.validate(value, required=True)
         except exceptions.ValidationError as exc:
             raise exceptions.ValidationError(
-                "The element %s is not valid: %s" % (self.qname, exc.message),
+                f"The element {self.qname} is not valid: {exc.message}",
                 path=render_path,
             )
 
@@ -318,8 +311,8 @@ class Element(Base):
                 value = "{%s}" % value
 
         if standalone:
-            value = "%s(%s)" % (self.get_prefixed_name(schema), value)
+            value = f"{self.get_prefixed_name(schema)}({value})"
 
         if self.accepts_multiple:
-            return "%s[]" % value
+            return f"{value}[]"
         return value

--- a/src/zeep/xsd/elements/indicators.py
+++ b/src/zeep/xsd/elements/indicators.py
@@ -35,7 +35,7 @@ class Indicator(Base):
     """Base class for the other indicators"""
 
     def __repr__(self):
-        return "<%s(%s)>" % (self.__class__.__name__, super().__repr__())
+        return f"<{self.__class__.__name__}({super().__repr__()})>"
 
     @property
     def default_value(self):
@@ -191,8 +191,7 @@ class OrderIndicator(Indicator, list):
 
                 if item_kwargs:
                     raise TypeError(
-                        ("%s() got an unexpected keyword argument %r.")
-                        % (self, list(item_kwargs)[0])
+                        f"{self}() got an unexpected keyword argument {list(item_kwargs)[0]!r}."
                     )
 
                 result.append(subresult)
@@ -260,12 +259,12 @@ class OrderIndicator(Indicator, list):
                 parts.append(element.signature(schema, standalone=False))
             else:
                 value = element.signature(schema, standalone=False)
-                parts.append("%s: %s" % (name, value))
+                parts.append(f"{name}: {value}")
 
         part = ", ".join(parts)
 
         if self.accepts_multiple:
-            return "[%s]" % (part,)
+            return f"[{part}]"
         return part
 
 
@@ -444,8 +443,8 @@ class Choice(OrderIndicator):
                             break
                 else:
                     raise TypeError(
-                        "No complete xsd:Sequence found for the xsd:Choice %r.\n"
-                        "The signature is: %s" % (name, self.signature())
+                        f"No complete xsd:Sequence found for the xsd:Choice {name!r}.\n"
+                        f"The signature is: {self.signature()}"
                     )
 
             if not self.accepts_multiple:
@@ -574,9 +573,9 @@ class Choice(OrderIndicator):
                 parts.append(
                     "{%s: %s}" % (name, element.signature(schema, standalone=False))
                 )
-        part = "(%s)" % " | ".join(parts)
+        part = f"({' | '.join(parts)})"
         if self.accepts_multiple:
-            return "%s[]" % (part,)
+            return f"{part}[]"
         return part
 
 
@@ -696,8 +695,7 @@ class Group(Indicator):
 
                 if available_sub_kwargs:
                     raise TypeError(
-                        ("%s() got an unexpected keyword argument %r.")
-                        % (self, list(available_sub_kwargs)[0])
+                        f"{self}() got an unexpected keyword argument {list(available_sub_kwargs)[0]!r}."
                     )
 
                 if subresult:
@@ -750,6 +748,6 @@ class Group(Indicator):
     def signature(self, schema=None, standalone=True):
         name = create_prefixed_name(self.qname, schema)
         if standalone:
-            return "%s(%s)" % (name, self.child.signature(schema, standalone=False))
+            return f"{name}({self.child.signature(schema, standalone=False)})"
         else:
             return self.child.signature(schema, standalone=False)

--- a/src/zeep/xsd/printer.py
+++ b/src/zeep/xsd/printer.py
@@ -27,7 +27,7 @@ class PrettyPrinter:
             if num > 0:
                 for i, (key, value) in enumerate(obj.items()):
                     write(" " * (indent * level))
-                    write("'%s'" % key)
+                    write(f"'{key}'")
                     write(": ")
                     self._format(value, stream, level=level + 1)
                     if i < num - 1:

--- a/src/zeep/xsd/schema.py
+++ b/src/zeep/xsd/schema.py
@@ -47,10 +47,7 @@ class Schema:
     def __repr__(self):
         main_doc = self.root_document
         if main_doc:
-            return "<Schema(location=%r, tns=%r)>" % (
-                main_doc._location,
-                main_doc._target_namespace,
-            )
+            return f"<Schema(location={main_doc._location!r}, tns={main_doc._target_namespace!r})>"
         return "<Schema()>"
 
     @property
@@ -164,7 +161,7 @@ class Schema:
             except KeyError:
                 return self._prefix_map_auto[prefix]
         except KeyError:
-            raise ValueError("No such prefix %r" % prefix)
+            raise ValueError(f"No such prefix {prefix!r}")
 
     def get_shorthand_for_ns(self, namespace):
         for prefix, other_namespace in self._prefix_map_auto.items():
@@ -262,7 +259,7 @@ class Schema:
             elif prefix in self._prefix_map_auto:
                 return etree.QName(self._prefix_map_auto[prefix], localname)
             else:
-                raise ValueError("No namespace defined for the prefix %r" % prefix)
+                raise ValueError(f"No namespace defined for the prefix {prefix!r}")
         else:
             return etree.QName(name)
 
@@ -273,7 +270,7 @@ class Schema:
             if namespace is None or namespace in prefix_map.values():
                 continue
 
-            prefix_map["ns%d" % i] = namespace
+            prefix_map[f"ns{i}"] = namespace
             i += 1
         return prefix_map
 
@@ -323,7 +320,7 @@ class _SchemaContainer:
             if fail_silently:
                 return []
             raise exceptions.NamespaceError(
-                "No schema available for the namespace %r" % namespace
+                f"No schema available for the namespace {namespace!r}"
             )
         return self._instances[namespace]
 
@@ -382,10 +379,9 @@ class SchemaDocument:
         # self._xml_schema = None
 
     def __repr__(self):
-        return "<SchemaDocument(location=%r, tns=%r, is_empty=%r)>" % (
-            self._location,
-            self._target_namespace,
-            self.is_empty,
+        return (
+            "<SchemaDocument"
+            f"(location={self._location!r}, tns={self._target_namespace!r}, is_empty={self.is_empty!r})>"
         )
 
     @property

--- a/src/zeep/xsd/types/base.py
+++ b/src/zeep/xsd/types/base.py
@@ -52,7 +52,7 @@ class Type:
         schema_type: "Type" = None,
     ) -> typing.Optional[typing.Union[str, CompoundValue, typing.List[etree._Element]]]:
         raise NotImplementedError(
-            "%s.parse_xmlelement() is not implemented" % self.__class__.__name__
+            f"{self.__class__.__name__}.parse_xmlelement() is not implemented"
         )
 
     def parsexml(self, xml, schema=None):
@@ -66,22 +66,22 @@ class Type:
         render_path=None,
     ) -> None:
         raise NotImplementedError(
-            "%s.render() is not implemented" % self.__class__.__name__
+            f"{self.__class__.__name__}.render() is not implemented"
         )
 
     def resolve(self):
         raise NotImplementedError(
-            "%s.resolve() is not implemented" % self.__class__.__name__
+            f"{self.__class__.__name__}.resolve() is not implemented"
         )
 
     def extend(self, child):
         raise NotImplementedError(
-            "%s.extend() is not implemented" % self.__class__.__name__
+            f"{self.__class__.__name__}.extend() is not implemented"
         )
 
     def restrict(self, child):
         raise NotImplementedError(
-            "%s.restrict() is not implemented" % self.__class__.__name__
+            f"{self.__class__.__name__}.restrict() is not implemented"
         )
 
     @property

--- a/src/zeep/xsd/types/builtins.py
+++ b/src/zeep/xsd/types/builtins.py
@@ -25,8 +25,7 @@ def check_no_collection(func):
     def _wrapper(self, value):
         if isinstance(value, (list, dict, set)):
             raise ValueError(
-                "The %s type doesn't accept collections as value"
-                % (self.__class__.__name__)
+                f"The {self.__class__.__name__} type doesn't accept collections as value"
             )
 
         return func(self, value)

--- a/src/zeep/xsd/types/complex.py
+++ b/src/zeep/xsd/types/complex.py
@@ -90,7 +90,7 @@ class ComplexType(AnyType):
         )
 
     def __str__(self):
-        return "%s(%s)" % (self.__class__.__name__, self.signature())
+        return f"{self.__class__.__name__}({self.signature()})"
 
     @threaded_cached_property
     def attributes(self):
@@ -101,7 +101,7 @@ class ComplexType(AnyType):
             if attr.name is None:
                 name = generator.get_name()
             elif attr.name in elm_names:
-                name = "attr__%s" % attr.name
+                name = f"attr__{attr.name}"
             else:
                 name = attr.name
             result.append((name, attr))
@@ -220,7 +220,7 @@ class ComplexType(AnyType):
             # Check if all children are consumed (parsed)
             if elements:
                 if schema and schema.settings.strict:
-                    raise XMLParseError("Unexpected element %r" % elements[0].tag)
+                    raise XMLParseError(f"Unexpected element {elements[0].tag!r}")
                 else:
                     init_kwargs["_raw_elements"] = elements
 
@@ -501,11 +501,11 @@ class ComplexType(AnyType):
             parts.append(part)
 
         for name, attribute in self.attributes:
-            part = "%s: %s" % (name, attribute.signature(schema, standalone=False))
+            part = f"{name}: {attribute.signature(schema, standalone=False)}"
             parts.append(part)
 
         value = ", ".join(parts)
         if standalone:
-            return "%s(%s)" % (self.get_prefixed_name(schema), value)
+            return f"{self.get_prefixed_name(schema)}({value})"
         else:
             return value

--- a/src/zeep/xsd/types/simple.py
+++ b/src/zeep/xsd/types/simple.py
@@ -63,7 +63,7 @@ class AnySimpleType(AnyType):
         )
 
     def __str__(self):
-        return "%s(value)" % (self.__class__.__name__)
+        return f"{self.__class__.__name__}(value)"
 
     def parse_xmlelement(
         self,

--- a/src/zeep/xsd/types/unresolved.py
+++ b/src/zeep/xsd/types/unresolved.py
@@ -18,7 +18,7 @@ class UnresolvedType(Type):
         self.schema = schema
 
     def __repr__(self):
-        return "<%s(qname=%r)>" % (self.__class__.__name__, self.qname.text)
+        return f"<{self.__class__.__name__}(qname={self.qname.text!r})>"
 
     def render(
         self,
@@ -28,8 +28,7 @@ class UnresolvedType(Type):
         render_path=None,
     ) -> None:
         raise RuntimeError(
-            "Unable to render unresolved type %s. This is probably a bug."
-            % (self.qname)
+            f"Unable to render unresolved type {self.qname}. This is probably a bug."
         )
 
     def resolve(self):
@@ -46,11 +45,7 @@ class UnresolvedCustomType(Type):
         self.base_type = base_type
 
     def __repr__(self):
-        return "<%s(qname=%r, base_type=%r)>" % (
-            self.__class__.__name__,
-            self.qname.text,
-            self.base_type,
-        )
+        return f"<{self.__class__.__name__}(qname={self.qname.text!r}, base_type={self.base_type!r})>"
 
     def resolve(self):
         base = self.base_type

--- a/src/zeep/xsd/utils.py
+++ b/src/zeep/xsd/utils.py
@@ -7,7 +7,7 @@ class NamePrefixGenerator:
         self._prefix = prefix
 
     def get_name(self):
-        retval = "%s%d" % (self._prefix, self._num)
+        retval = self._prefix + str(self._num)
         self._num += 1
         return retval
 
@@ -19,7 +19,7 @@ class UniqueNameGenerator:
     def create_name(self, name):
         if name in self._unique_count:
             self._unique_count[name] += 1
-            return "%s__%d" % (name, self._unique_count[name])
+            return f"{name}__{self._unique_count[name]}"
         else:
             self._unique_count[name] = 0
             return name
@@ -50,10 +50,10 @@ def create_prefixed_name(qname, schema):
     if schema and qname.namespace:
         prefix = schema.get_shorthand_for_ns(qname.namespace)
         if prefix:
-            return "%s:%s" % (prefix, qname.localname)
+            return f"{prefix}:{qname.localname}"
     elif qname.namespace in ns.NAMESPACE_TO_PREFIX:
         prefix = ns.NAMESPACE_TO_PREFIX[qname.namespace]
-        return "%s:%s" % (prefix, qname.localname)
+        return f"{prefix}:{qname.localname}"
 
     if qname.namespace:
         return qname.text

--- a/src/zeep/xsd/valueobjects.py
+++ b/src/zeep/xsd/valueobjects.py
@@ -24,11 +24,7 @@ class AnyObject:
         self.value = value
 
     def __repr__(self):
-        return "<%s(type=%r, value=%r)>" % (
-            self.__class__.__name__,
-            self.xsd_elm,
-            self.value,
-        )
+        return "<{self.__class__.__name__}(type={self.xsd_elm!r}, value={self.value!r})>"
 
     def __deepcopy__(self, memo):
         return type(self)(self.xsd_elm, copy.deepcopy(self.value))
@@ -154,7 +150,7 @@ class CompoundValue:
             return self.__values__[key]
         except KeyError:
             raise AttributeError(
-                "%s instance has no attribute '%s'" % (self.__class__.__name__, key)
+                f"{self.__class__.__name__} instance has no attribute '{key}'"
             )
 
     def __deepcopy__(self, memo):
@@ -206,8 +202,7 @@ def _process_signature(xsd_type, args, kwargs):
 
         if num_args > index:
             raise TypeError(
-                "__init__() takes at most %s positional arguments (%s given)"
-                % (len(result), num_args)
+                f"__init__() takes at most {len(result)} positional arguments ({num_args} given)"
             )
 
     # Process the named arguments (sequence/group/all/choice). The

--- a/src/zeep/xsd/visitor.py
+++ b/src/zeep/xsd/visitor.py
@@ -89,7 +89,7 @@ class SchemaVisitor:
     def process(self, node, parent):
         visit_func = self.visitors.get(node.tag)
         if not visit_func:
-            raise ValueError("No visitor defined for %r" % node.tag)
+            raise ValueError(f"No visitor defined for {node.tag!r}")
         result = visit_func(self, node, parent)
         return result
 
@@ -245,9 +245,8 @@ class SchemaVisitor:
             raise XMLParseError(
                 (
                     "The namespace defined on the xsd:import doesn't match the "
-                    "imported targetNamespace located at %r "
-                )
-                % (location),
+                    f"imported targetNamespace located at {location!r} "
+                ),
                 filename=self.document._location,
                 sourceline=node.sourceline,
             )
@@ -550,7 +549,7 @@ class SchemaVisitor:
         elif child.tag == tags.union:
             xsd_type = self.visit_union(child, node)
         else:
-            raise AssertionError("Unexpected child: %r" % child.tag)
+            raise AssertionError(f"Unexpected child: {child.tag!r}")
 
         assert xsd_type is not None
         if is_global:
@@ -923,7 +922,7 @@ class SchemaVisitor:
         for child in children:
             if child.tag not in sub_types:
                 raise self._create_error(
-                    "Unexpected element %s in xsd:sequence" % child.tag, child
+                    f"Unexpected element {child.tag} in xsd:sequence", child
                 )
 
             item = self.process(child, node)
@@ -1250,7 +1249,7 @@ class SchemaVisitor:
                 attribute = self.process(child, node)
                 attributes.append(attribute)
             else:
-                raise self._create_error("Unexpected tag `%s`" % (child.tag), node)
+                raise self._create_error(f"Unexpected tag `{child.tag}`", node)
         return attributes
 
     def _create_error(self, message, node):


### PR DESCRIPTION
This is a simple refactor to replace most string formatting methods with f-strings. Found via pylint.

F-strings are considered more readable and more performant than other string formatting options. This PR does not attempt to fix any mistakes, it should produce functionally identical code.