### PR TITLE
remove pytz

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = { text = "MIT" }
 authors = [
     { name = "Michael van Tellingen", email = "michaelvantellingen@gmail.com" }
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
@@ -27,7 +27,6 @@ dependencies = [
     "requests>=2.7.0",
     "requests-toolbelt>=0.7.1",
     "requests-file>=1.5.1",
-    "pytz",
 ]
 
 [project.urls]

--- a/src/zeep/cache.py
+++ b/src/zeep/cache.py
@@ -8,7 +8,6 @@ from contextlib import contextmanager
 from typing import Dict, Tuple, Union
 
 import platformdirs
-import pytz
 
 # The sqlite3 is not available on Google App Engine so we handle the
 # ImportError here and set the sqlite3 var to None.
@@ -169,8 +168,8 @@ def _is_expired(value, timeout):
     if timeout is None:
         return False
 
-    now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=pytz.utc)
-    max_age = value.replace(tzinfo=pytz.utc)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    max_age = value.replace(tzinfo=datetime.timezone.utc)
     max_age += datetime.timedelta(seconds=timeout)
     return now > max_age
 

--- a/src/zeep/wsse/utils.py
+++ b/src/zeep/wsse/utils.py
@@ -1,7 +1,6 @@
 import datetime
 from uuid import uuid4
 
-import pytz
 from lxml import etree
 from lxml.builder import ElementMaker
 
@@ -29,7 +28,7 @@ def get_security_header(doc):
 
 def get_timestamp(timestamp=None, zulu_timestamp=None):
     timestamp = timestamp or datetime.datetime.now(datetime.timezone.utc)
-    timestamp = timestamp.replace(tzinfo=pytz.utc, microsecond=0)
+    timestamp = timestamp.replace(tzinfo=datetime.timezone.utc, microsecond=0)
     if zulu_timestamp:
         return timestamp.isoformat().replace("+00:00", "Z")
     else:

--- a/src/zeep/xsd/types/builtins.py
+++ b/src/zeep/xsd/types/builtins.py
@@ -5,7 +5,6 @@ import re
 from decimal import Decimal as _Decimal
 
 import isodate
-import pytz
 
 from zeep.xsd.const import xsd_ns
 from zeep.xsd.types.any import AnyType
@@ -548,12 +547,12 @@ class PositiveInteger(NonNegativeInteger):
 ##
 # Other
 def _parse_timezone(val):
-    """Return a pytz.tzinfo object"""
+    """Return a datetime.timezone object"""
     if not val:
         return
 
     if val == "Z" or val == "+00:00":
-        return pytz.utc
+        return datetime.timezone.utc
 
     negative = val.startswith("-")
     minutes = int(val[-2:])
@@ -561,18 +560,18 @@ def _parse_timezone(val):
 
     if negative:
         minutes = 0 - minutes
-    return pytz.FixedOffset(minutes)
+    return datetime.timezone(datetime.timedelta(minutes=minutes))
 
 
 def _unparse_timezone(tzinfo):
     if not tzinfo:
         return ""
 
-    if tzinfo == pytz.utc:
+    if tzinfo == datetime.timezone.utc:
         return "Z"
 
-    hours = math.floor(tzinfo._minutes / 60)
-    minutes = tzinfo._minutes % 60
+    hours = math.floor(tzinfo.utcoffset(None).total_seconds() / 60 / 60)
+    minutes = tzinfo.utcoffset(None).total_seconds() / 60 / 60 - hours
 
     if hours > 0:
         return "+%02d:%02d" % (hours, minutes)

--- a/tests/test_xsd_builtins.py
+++ b/tests/test_xsd_builtins.py
@@ -3,7 +3,7 @@ from decimal import Decimal as D
 
 import isodate
 import pytest
-import pytz
+from datetime import timedelta, timezone
 
 from zeep.xsd.types import builtins
 
@@ -161,13 +161,13 @@ class TestDateTime:
         value = datetime.datetime(2016, 3, 4, 21, 14, 42)
         assert instance.xmlvalue(value) == "2016-03-04T21:14:42"
 
-        value = datetime.datetime(2016, 3, 4, 21, 14, 42, tzinfo=pytz.utc)
+        value = datetime.datetime(2016, 3, 4, 21, 14, 42, tzinfo=timezone.utc)
         assert instance.xmlvalue(value) == "2016-03-04T21:14:42Z"
 
-        value = datetime.datetime(2016, 3, 4, 21, 14, 42, 123456, tzinfo=pytz.utc)
+        value = datetime.datetime(2016, 3, 4, 21, 14, 42, 123456, tzinfo=timezone.utc)
         assert instance.xmlvalue(value) == "2016-03-04T21:14:42.123456Z"
 
-        value = datetime.datetime(2016, 3, 4, 21, 14, 42, tzinfo=pytz.utc)
+        value = datetime.datetime(2016, 3, 4, 21, 14, 42, tzinfo=timezone.utc)
         value = value.astimezone(pytz.timezone("Europe/Amsterdam"))
         assert instance.xmlvalue(value) == "2016-03-04T22:14:42+01:00"
 
@@ -262,7 +262,7 @@ class TestgYearMonth:
     def test_xmlvalue(self):
         instance = builtins.gYearMonth()
         assert instance.xmlvalue((2012, 10, None)) == "2012-10"
-        assert instance.xmlvalue((2012, 10, pytz.utc)) == "2012-10Z"
+        assert instance.xmlvalue((2012, 10, timezone.utc)) == "2012-10Z"
 
     def test_pythonvalue(self):
         instance = builtins.gYearMonth()
@@ -270,10 +270,10 @@ class TestgYearMonth:
         assert instance.pythonvalue("2001-10+02:00") == (
             2001,
             10,
-            pytz.FixedOffset(120),
+            timezone(timedelta(minutes=120)),
         )
-        assert instance.pythonvalue("2001-10Z") == (2001, 10, pytz.utc)
-        assert instance.pythonvalue("2001-10+00:00") == (2001, 10, pytz.utc)
+        assert instance.pythonvalue("2001-10Z") == (2001, 10, timezone.utc)
+        assert instance.pythonvalue("2001-10+00:00") == (2001, 10, timezone.utc)
         assert instance.pythonvalue("-2001-10") == (-2001, 10, None)
         assert instance.pythonvalue("-20001-10") == (-20001, 10, None)
 
@@ -285,19 +285,19 @@ class TestgYear:
     def test_xmlvalue(self):
         instance = builtins.gYear()
         assert instance.xmlvalue((2001, None)) == "2001"
-        assert instance.xmlvalue((2001, pytz.utc)) == "2001Z"
+        assert instance.xmlvalue((2001, timezone.utc)) == "2001Z"
 
     def test_pythonvalue(self):
         instance = builtins.gYear()
         assert instance.pythonvalue("2001") == (2001, None)
-        assert instance.pythonvalue("2001+02:00") == (2001, pytz.FixedOffset(120))
-        assert instance.pythonvalue("2001Z") == (2001, pytz.utc)
-        assert instance.pythonvalue("2001+00:00") == (2001, pytz.utc)
+        assert instance.pythonvalue("2001+02:00") == (2001, timezone(timedelta(minutes=120)))
+        assert instance.pythonvalue("2001Z") == (2001, timezone.utc)
+        assert instance.pythonvalue("2001+00:00") == (2001, timezone.utc)
         assert instance.pythonvalue("-2001") == (-2001, None)
         assert instance.pythonvalue("-20000") == (-20000, None)
         assert instance.pythonvalue("  \t2001+02:00\r\n ") == (
             2001,
-            pytz.FixedOffset(120),
+            timezone(timedelta(minutes=120)),
         )
 
         with pytest.raises(builtins.ParseError):
@@ -312,9 +312,9 @@ class TestgMonthDay:
     def test_pythonvalue(self):
         instance = builtins.gMonthDay()
         assert instance.pythonvalue("--05-01") == (5, 1, None)
-        assert instance.pythonvalue("--11-01Z") == (11, 1, pytz.utc)
-        assert instance.pythonvalue("--11-01+02:00") == (11, 1, pytz.FixedOffset(120))
-        assert instance.pythonvalue("--11-01-04:00") == (11, 1, pytz.FixedOffset(-240))
+        assert instance.pythonvalue("--11-01Z") == (11, 1, timezone.utc)
+        assert instance.pythonvalue("--11-01+02:00") == (11, 1, timezone(timedelta(minutes=120)))
+        assert instance.pythonvalue("--11-01-04:00") == (11, 1, timezone(timedelta(minutes=-240)))
         assert instance.pythonvalue("--11-15") == (11, 15, None)
         assert instance.pythonvalue("--02-29") == (2, 29, None)
         assert instance.pythonvalue("\t\r\n --05-01 ") == (5, 1, None)
@@ -331,12 +331,12 @@ class TestgMonth:
     def test_pythonvalue(self):
         instance = builtins.gMonth()
         assert instance.pythonvalue("--05") == (5, None)
-        assert instance.pythonvalue("--11Z") == (11, pytz.utc)
-        assert instance.pythonvalue("--11+02:00") == (11, pytz.FixedOffset(120))
-        assert instance.pythonvalue("--11-04:00") == (11, pytz.FixedOffset(-240))
+        assert instance.pythonvalue("--11Z") == (11, timezone.utc)
+        assert instance.pythonvalue("--11+02:00") == (11, timezone(timedelta(minutes=120)))
+        assert instance.pythonvalue("--11-04:00") == (11, timezone(timedelta(minutes=-240)))
         assert instance.pythonvalue("--11") == (11, None)
         assert instance.pythonvalue("--02") == (2, None)
-        assert instance.pythonvalue("\n\t --11Z \r") == (11, pytz.utc)
+        assert instance.pythonvalue("\n\t --11Z \r") == (11, timezone.utc)
 
         with pytest.raises(builtins.ParseError):
             assert instance.pythonvalue("99")
@@ -349,18 +349,18 @@ class TestgDay:
         value = (1, None)
         assert instance.xmlvalue(value) == "---01"
 
-        value = (1, pytz.FixedOffset(120))
+        value = (1, timezone(timedelta(minutes=120)))
         assert instance.xmlvalue(value) == "---01+02:00"
 
-        value = (1, pytz.FixedOffset(-240))
+        value = (1, timezone(timedelta(minutes=-240)))
         assert instance.xmlvalue(value) == "---01-04:00"
 
     def test_pythonvalue(self):
         instance = builtins.gDay()
         assert instance.pythonvalue("---01") == (1, None)
-        assert instance.pythonvalue("---01Z") == (1, pytz.utc)
-        assert instance.pythonvalue("---01+02:00") == (1, pytz.FixedOffset(120))
-        assert instance.pythonvalue("---01-04:00") == (1, pytz.FixedOffset(-240))
+        assert instance.pythonvalue("---01Z") == (1, timezone.utc)
+        assert instance.pythonvalue("---01+02:00") == (1, timezone(timedelta(minutes=120)))
+        assert instance.pythonvalue("---01-04:00") == (1, timezone(timedelta(minutes=-240)))
         assert instance.pythonvalue("---15") == (15, None)
         assert instance.pythonvalue("---31") == (31, None)
         assert instance.pythonvalue("\r\n  \t---31 ") == (31, None)


### PR DESCRIPTION
To keep it simple, I made it so it imply to drop support for python 3.8, [which is already OEL](https://devguide.python.org/versions/).
Though, I still have this error I am not sure about:

```
tests/test_xsd_builtins.py:158 (TestDateTime.test_xmlvalue)
'2016-03-04T21:14:42+00:00' != '2016-03-04T21:14:42Z'

Expected :'2016-03-04T21:14:42Z'
Actual   :'2016-03-04T21:14:42+00:00'

<Click to see difference>


self = <tests.test_xsd_builtins.TestDateTime object at 0x1036aa090>

    def test_xmlvalue(self):
        instance = builtins.DateTime()
        value = datetime.datetime(2016, 3, 4, 21, 14, 42)
        assert instance.xmlvalue(value) == "2016-03-04T21:14:42"
    
        value = datetime.datetime(2016, 3, 4, 21, 14, 42, tzinfo=timezone.utc)
>       assert instance.xmlvalue(value) == "2016-03-04T21:14:42Z"
E       AssertionError: assert '2016-03-04T21:14:42+00:00' == '2016-03-04T21:14:42Z'
E         
E         - 2016-03-04T21:14:42Z
E         ?                    ^
E         + 2016-03-04T21:14:42+00:00
E         ?                    ^^^^^^

tests/test_xsd_builtins.py:165: AssertionError
```