### PR TITLE
Remove REPL artifacts from WSSE documentation

### DIFF
--- a/docs/wsse.rst
+++ b/docs/wsse.rst
@@ -5,13 +5,15 @@ WS-Security incorporates security features in the header of a SOAP message.
 
 UsernameToken
 -------------
-The UsernameToken supports both the passwordText and passwordDigest methods::
+The UsernameToken supports both the passwordText and passwordDigest methods:
 
-    >>> from zeep import Client
-    >>> from zeep.wsse.username import UsernameToken
-    >>> client = Client(
-    ...     'http://www.webservicex.net/ConvertSpeed.asmx?WSDL', 
-    ...     wsse=UsernameToken('username', 'password'))
+.. code-block:: python
+
+    from zeep import Client
+    from zeep.wsse.username import UsernameToken
+    client = Client(
+        'http://www.webservicex.net/ConvertSpeed.asmx?WSDL', 
+        wsse=UsernameToken('username', 'password'))
 
 To use the passwordDigest method you need to supply `use_digest=True` to the
 `UsernameToken` class.
@@ -26,28 +28,32 @@ platform.
 
 To append the security token as `BinarySecurityToken`, you can use wsse.BinarySignature() plugin.
 
-Example usage A::
+Example usage A:
 
-    >>> from zeep import Client
-    >>> from zeep.wsse.signature import Signature
-    >>> client = Client(
-    ...     'http://www.webservicex.net/ConvertSpeed.asmx?WSDL', 
-    ...     wsse=Signature(
-    ...         private_key_filename, public_key_filename, 
-    ...         optional_password))
+.. code-block:: python
 
-Example usage B::
+    from zeep import Client
+    from zeep.wsse.signature import Signature
+    client = Client(
+        'http://www.webservicex.net/ConvertSpeed.asmx?WSDL', 
+        wsse=Signature(
+            private_key_filename, public_key_filename, 
+            optional_password))
 
-    >>> from zeep import Client
-    >>> from zeep.wsse.signature import Signature
-    >>> from zeep.transports import Transport
-    >>> from requests import Session
-    >>> session = Session()
-    >>> session.cert = '/path/to/ssl.pem'
-    >>> transport = Transport(session=session)
-    >>> client = Client(
-    ...     'http://www.webservicex.net/ConvertSpeed.asmx?WSDL',
-    ...     transport=transport)
+Example usage B:
+
+.. code-block:: python
+
+    from zeep import Client
+    from zeep.wsse.signature import Signature
+    from zeep.transports import Transport
+    from requests import Session
+    session = Session()
+    session.cert = '/path/to/ssl.pem'
+    transport = Transport(session=session)
+    client = Client(
+        'http://www.webservicex.net/ConvertSpeed.asmx?WSDL',
+        transport=transport)
     
 .. _xmlsec: https://pypi.python.org/pypi/xmlsec
 .. _README: https://github.com/mehcode/python-xmlsec
@@ -59,15 +65,17 @@ UsernameToken and Signature together
 To use UsernameToken and Signature together, then you can pass both together
 to the client in a list
 
-    >>> from zeep import Client
-    >>> from zeep.wsse.username import UsernameToken
-    >>> from zeep.wsse.signature import Signature
-    >>> user_name_token = UsernameToken('username', 'password')
-    >>> signature = Signature(private_key_filename, public_key_filename,
-    ...     optional_password)
-    >>> client = Client(
-    ...     'http://www.webservicex.net/ConvertSpeed.asmx?WSDL',
-    ...     wsse=[user_name_token, signature])
+.. code-block:: python
+
+    from zeep import Client
+    from zeep.wsse.username import UsernameToken
+    from zeep.wsse.signature import Signature
+    user_name_token = UsernameToken('username', 'password')
+    signature = Signature(private_key_filename, public_key_filename,
+        optional_password)
+    client = Client(
+        'http://www.webservicex.net/ConvertSpeed.asmx?WSDL',
+        wsse=[user_name_token, signature])
 
 
 UsernameToken with Timestamp token
@@ -77,19 +85,21 @@ To use UsernameToken with Timestamp token, first you need an instance of `WSU.Ti
 containing `WSU.Created()` and `WSU.Expired()` elements, finally pass it as `timestamp_token` keyword argument
 to `UsernameToken()`.
 
-    >>> import datetime
-    >>> from zeep import Client
-    >>> from zeep.wsse.username import UsernameToken
-    >>> from zeep.wsse.utils import WSU
-    >>> timestamp_token = WSU.Timestamp()
-    >>> today_datetime = datetime.datetime.today()
-    >>> expires_datetime = today_datetime + datetime.timedelta(minutes=10)
-    >>> timestamp_elements = [
-    ...         WSU.Created(today_datetime.strftime("%Y-%m-%dT%H:%M:%SZ")),
-    ...         WSU.Expires(expires_datetime.strftime("%Y-%m-%dT%H:%M:%SZ"))
-    ...]
-    >>> timestamp_token.extend(timestamp_elements)
-    >>> user_name_token = UsernameToken('username', 'password', timestamp_token=timestamp_token)
-    >>> client = Client(
-    ...     'http://www.webservicex.net/ConvertSpeed.asmx?WSDL', wsse=user_name_token
-    ...)
+.. code-block:: python
+
+    import datetime
+    from zeep import Client
+    from zeep.wsse.username import UsernameToken
+    from zeep.wsse.utils import WSU
+    timestamp_token = WSU.Timestamp()
+    today_datetime = datetime.datetime.today()
+    expires_datetime = today_datetime + datetime.timedelta(minutes=10)
+    timestamp_elements = [
+            WSU.Created(today_datetime.strftime("%Y-%m-%dT%H:%M:%SZ")),
+            WSU.Expires(expires_datetime.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    ]
+    timestamp_token.extend(timestamp_elements)
+    user_name_token = UsernameToken('username', 'password', timestamp_token=timestamp_token)
+    client = Client(
+        'http://www.webservicex.net/ConvertSpeed.asmx?WSDL', wsse=user_name_token
+    )


### PR DESCRIPTION
Copy-pasting examples from WSSE section of the docs was such a pain as I had to remove those `>>>` and `...` every time.
SOAP is enough of a struggle to further shake your mental health dealing with that.