### PR TITLE
fix(transports): allow headers extension with AsyncTransport

### DIFF
--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -195,12 +195,12 @@ class AsyncTransport(Transport):
         )
         self.logger = logging.getLogger(__name__)
 
-        self.wsdl_client.headers = {
-            "User-Agent": "Zeep/%s (www.python-zeep.org)" % (get_version())
-        }
-        self.client.headers = {
-            "User-Agent": "Zeep/%s (www.python-zeep.org)" % (get_version())
-        }
+        self.wsdl_client.headers["User-Agent"] = "Zeep/%s (www.python-zeep.org)" % (
+            get_version()
+        )
+        self.client.headers["User-Agent"] = "Zeep/%s (www.python-zeep.org)" % (
+            get_version()
+        )
 
     async def aclose(self):
         await self.client.aclose()


### PR DESCRIPTION
Currently, when passing a custom (wsdl) client with arbitrary headers set, they get overwritten only to set the User-Agent.
Let's make sure the User-Agent only gets added/modified rather.