### PR TITLE
Add Fault default message value

### DIFF
--- a/src/zeep/exceptions.py
+++ b/src/zeep/exceptions.py
@@ -56,7 +56,7 @@ class NamespaceError(Error):
 
 
 class Fault(Error):
-    def __init__(self, message, code=None, actor=None, detail=None, subcodes=None):
+    def __init__(self, message="", code=None, actor=None, detail=None, subcodes=None):
         super().__init__(message)
         self.message = message
         self.code = code


### PR DESCRIPTION
The TransportError has a default message value. The Fault Error does not have this. It is nice to have consistency in this. 

I was raising a TransportError and changed it to a Fault and this broke the code as it now expected a message value as input. 