### PR TITLE
Fixed wrong proxy keyword (httpx)

### DIFF
--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -185,12 +185,12 @@ class AsyncTransport(Transport):
         self.cache = cache
         self.wsdl_client = wsdl_client or httpx.Client(
             verify=verify_ssl,
-            proxies=proxy,
+            proxy=proxy,
             timeout=timeout,
         )
         self.client = client or httpx.AsyncClient(
             verify=verify_ssl,
-            proxies=proxy,
+            proxy=proxy,
             timeout=operation_timeout,
         )
         self.logger = logging.getLogger(__name__)


### PR DESCRIPTION
Reverted PR #1149 since HTTPX now uses the keyword "proxy" instead of "proxies" (https://www.python-httpx.org/advanced/proxies/) to create any proxy values, this always throws an error when creating an AsyncTransport object if using the latest httpx version.