### PR TITLE
Fix zeep for httpx after 0.28.0

### DIFF
--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -185,13 +185,13 @@ class AsyncTransport(Transport):
         self.cache = cache
         self.wsdl_client = wsdl_client or httpx.Client(
             verify=verify_ssl,
-            proxies=proxy,
             timeout=timeout,
+            **({"proxies": proxy} if httpx.__version__ < "0.28.0" else {"proxy": proxy}),
         )
         self.client = client or httpx.AsyncClient(
             verify=verify_ssl,
-            proxies=proxy,
             timeout=operation_timeout,
+            **({"proxies": proxy} if httpx.__version__ < "0.28.0" else {"proxy": proxy}),
         )
         self.logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Current version of zeep is actually incompatible with `httpx>=0.28.0`.

See https://github.com/encode/httpx/releases/tag/0.28.0 for removal of `proxies` keyword.
See https://github.com/encode/httpx/releases/tag/0.26.0 for deprecation of `proxies` keyword.