### PR TITLE
Adds indent to _create for when no client is present

### DIFF
--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -99,9 +99,9 @@ class SoapBinding(Binding):
                 else:
                     envelope, http_headers = client.wsse.apply(envelope, http_headers)
 
-        # Add extra http headers from the setings object
-        if client.settings.extra_http_headers:
-            http_headers.update(client.settings.extra_http_headers)
+            # Add extra http headers from the setings object
+            if client.settings.extra_http_headers:
+                http_headers.update(client.settings.extra_http_headers)
 
         return envelope, http_headers
 


### PR DESCRIPTION
Fixes: #1475 

The SoapBinding Class has the possibility / the option for the client to be None.

However, when the client is None, the code fails on 

```
            # Add extra http headers from the setings object
            if client.settings.extra_http_headers:
                http_headers.update(client.settings.extra_http_headers)
```

which falls outside the ```if client``` specified above. An extra indent to those lines fixes the problem.