### PR TITLE
Fix xsd:import without namespace incorrectly inheriting parent targetNamespace

### DIFF
--- a/src/zeep/xsd/visitor.py
+++ b/src/zeep/xsd/visitor.py
@@ -199,14 +199,11 @@ class SchemaVisitor:
                 sourceline=node.sourceline,
             )
 
-        # We found an empty <import/> statement, this needs to trigger 4.1.2
-        # from https://www.w3.org/TR/2012/REC-xmlschema11-1-20120405/#src-resolve
-        # for QName resolving.
-        # In essence this means we will resolve QNames without a namespace to no
-        # namespace instead of the target namespace.
-        # The following code snippet works because imports have to occur before we
-        # visit elements.
-        if not namespace and not location:
+        # Per W3C XSD 4.1.2 (https://www.w3.org/TR/2012/REC-xmlschema11-1-20120405/#src-resolve):
+        # an import without a namespace attribute provides access to the no-namespace
+        # components. In that case unqualified QNames should resolve to no namespace
+        # instead of the target namespace.
+        if not namespace:
             self.document._has_empty_import = True
 
         # Check if the schema is already imported before based on the
@@ -251,12 +248,6 @@ class SchemaVisitor:
                 filename=self.document._location,
                 sourceline=node.sourceline,
             )
-
-        # If the imported schema doesn't define a target namespace and the
-        # node doesn't specify it either then inherit the existing target
-        # namespace.
-        elif not schema_tns and not namespace:
-            namespace = self.document._target_namespace
 
         schema = self.schema.create_new_document(
             schema_node, location, target_namespace=namespace

--- a/tests/test_wsdl.py
+++ b/tests/test_wsdl.py
@@ -1268,6 +1268,78 @@ def test_import_cyclic():
     )
 
 
+def test_import_schema_without_namespace_and_header():
+    """An xsd:import with schemaLocation but no namespace attribute that
+    points to a schema without targetNamespace should not inherit the
+    parent schema's targetNamespace.  When the imported element is used
+    in a soap:header binding, the unqualified QName must still resolve.
+    """
+    xsd_content = (
+        b'<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">'
+        b'<xs:element name="Header" type="xs:string"/>'
+        b"</xs:schema>"
+    )
+
+    wsdl_main = StringIO(
+        """\
+    <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+        xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+        xmlns:tns="http://tests.python-zeep.org/tns"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="http://tests.python-zeep.org/tns" name="TestService">
+      <wsdl:types>
+        <xsd:schema targetNamespace="http://tests.python-zeep.org/tns">
+          <xsd:import schemaLocation="http://tests.python-zeep.org/header.xsd"/>
+          <xsd:element name="Request" type="xsd:string"/>
+        </xsd:schema>
+      </wsdl:types>
+      <wsdl:message name="InputMsg">
+        <wsdl:part name="body" element="tns:Request"/>
+      </wsdl:message>
+      <wsdl:message name="HeaderMsg">
+        <wsdl:part name="h" element="Header"/>
+      </wsdl:message>
+      <wsdl:portType name="TestPort">
+        <wsdl:operation name="Op">
+          <wsdl:input message="tns:InputMsg"/>
+          <wsdl:output message="tns:InputMsg"/>
+        </wsdl:operation>
+      </wsdl:portType>
+      <wsdl:binding name="TestBinding" type="tns:TestPort">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="Op">
+          <soap:operation soapAction="Op"/>
+          <wsdl:input>
+            <soap:body use="literal"/>
+            <soap:header message="tns:HeaderMsg" part="h" use="literal"/>
+          </wsdl:input>
+          <wsdl:output>
+            <soap:body use="literal"/>
+          </wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:service name="TestService">
+        <wsdl:port name="TestPort" binding="tns:TestBinding">
+          <soap:address location="http://tests.python-zeep.org/endpoint"/>
+        </wsdl:port>
+      </wsdl:service>
+    </wsdl:definitions>
+    """
+    )
+
+    transport = DummyTransport()
+    transport.bind("http://tests.python-zeep.org/header.xsd", xsd_content)
+
+    document = wsdl.Document(
+        wsdl_main, transport, "http://tests.python-zeep.org/test.wsdl"
+    )
+
+    service = document.services.get("TestService")
+    assert service is not None
+    port = service.ports.get("TestPort")
+    assert port is not None
+
+
 def test_import_no_location():
     node_a = etree.fromstring(
         """


### PR DESCRIPTION
The block at lines 255-259 of `src/zeep/xsd/visitor.py` (`elif not schema_tns and not namespace: namespace = self.document._target_namespace`) forces an `xsd:import schemaLocation="..."` without a `namespace` attribute to inherit the importing schema's `targetNamespace`. That is `xsd:include` semantics, not `xsd:import` semantics. The practical effect: elements declared in the imported no-namespace schema get re-registered under the parent namespace, and any unqualified QName referencing them (typically `wsdl:part element="Header"` in a `soap:header` binding) fails to resolve, surfacing as `IndexError: No definition '{tns}Header' in 'messages' found`. WCF/.NET-generated WSDLs hit this routinely.

The block was introduced in 713c779 ("Fix an issue with resolving qualified qname's used in references", #879, Dec 2018). One week later #888 / b7ad93e partially reverted the chameleon support and added the `_has_empty_import` flag, but only for the `<import/>` case (no namespace, no location). At the time @mvantellingen noted "I'm wondering if that unittest is actually ok" and @apollo13 replied "Not sure if the test is wrong or the code needs more work". That uncertainty was never resolved. Issues #600 (Jan 2018) and #662 (Jun 2018) report the same symptom against WCF WSDLs and have stayed open or closed-without-fix since.

## Fix

Two changes in `visit_import`:

1. The inheritance block is removed.
2. `_has_empty_import` is activated whenever an import omits `namespace`, per W3C XSD 4.1.2. The activation is placed at the three exit points so that an import naming a namespace incorrectly (which the existing `XMLParseError` rejects a few lines later) cannot poison the parent's QName resolution: on a cache hit, only when the cached document has no `_target_namespace`; on the canonical empty `<import/>`, in the missing-`schemaLocation` branch; and post-load, only when the imported schema has no `targetNamespace` either.

`tests/test_wsdl.py::test_import_schema_without_namespace_and_header` reproduces the original failure (namespaced schema importing a no-namespace schema whose element is used as a SOAP header part) and asserts both that the element ends up under the null namespace and that no `{tns}Header` ghost registration exists.

## Breaking change

Strict W3C QName resolution has a real consequence. In a schema with `elementFormDefault="qualified"` that does `<xsd:import schemaLocation="..."/>` (no `namespace`) of a no-namespace schema, an unqualified `ref` to an element defined in the *same* importing schema now resolves in the null namespace and fails. The spec-compliant fix on the consumer side is the qualified form:

    <xsd:element ref="tns:local"/>

This case is captured in `tests/test_xsd_schemas.py::test_no_target_namespace_unqualified_ref_to_own_element`, marked `xfail(strict=True)` so any future change is a deliberate one. No existing test in the repository hits this pattern.