### PR TITLE
Remove support for Python 3.9, add 3.14

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: "3.13"
 
     - name: Install build requirements
       run: python -m pip install wheel build

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: "3.13"
 
     - name: Install dependencies
       run: pip install tox
@@ -32,10 +32,10 @@ jobs:
       max-parallel: 4
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         # # TODO: Remove Windows exclusion when binary wheel available for lxml
         # exclude:
-        #   - { platform: windows-latest, python-version: "3.11" }
+        #   - { platform: windows-latest, python-version: "3.14" }
 
 
     steps:
@@ -89,10 +89,10 @@ jobs:
         merge-multiple: true
         path: .
 
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: "3.13"
 
     - name: Install dependencies
       run: |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A Python SOAP client
 
 ## Highlights:
-- Compatible with Python 3.9, 3.10, 3.11, 3.12, 3.13 and PyPy3
+- Compatible with Python 3.10, 3.11, 3.12, 3.13, 3.14 and PyPy3
 - Built on top of lxml, requests, and httpx
 - Support for Soap 1.1, Soap 1.2, and HTTP bindings
 - Support for WS-Addressing headers

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ Zeep: Python SOAP client
 A Python SOAP client
 
 Highlights:
- * Compatible with Python 3.9, 3.10, 3.11, 3.12, 3.13 and PyPy
+ * Compatible with Python 3.10, 3.11, 3.12, 3.13, 3.14 and PyPy
  * Build on top of lxml and requests
  * Support for Soap 1.1, Soap 1.2 and HTTP bindings
  * Support for WS-Addressing headers

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 files = src/, benchmark/, examples/, tests/
 ignore_missing_imports = True
 implicit_reexport = False
-python_version = 3.7
+python_version = 3.10
 warn_unused_configs = True
 mypy_path = src
 warn_unreachable = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,15 +7,15 @@ license = { text = "MIT" }
 authors = [
     { name = "Michael van Tellingen", email = "michaelvantellingen@gmail.com" }
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = py{39,310,311,312,313}-{mac,linux,windows},pypy
+envlist = py{310,311,312,313,314}-{mac,linux,windows},pypy
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
 
 
 [testenv]
@@ -17,12 +17,12 @@ platform =
     linux: linux
 extras =
     test
-    py{39,310,311,312}-{mac,linux}: xmlsec # Skip xmlsec on Python 3.13 for now
-    py{39,310,311,312,313}: async
+    py{310,311,312,313}-{mac,linux}: xmlsec # Skip xmlsec on Python 3.14 for now
+    py{310,311,312,313,314}: async
 deps =
-    py{39,310,311,312,313}: aioresponses==0.5.0
-    py{39,310,311,312,313}: aiohttp==3.7.4
-    py{39,310,311,312,313}: pytest-asyncio==0.11.0
+    py{310,311,312,313,314}: aioresponses==0.5.0
+    py{310,311,312,313,314}: aiohttp==3.7.4
+    py{310,311,312,313,314}: pytest-asyncio>=0.24,<1.0
 commands = coverage run --parallel -m pytest {posargs}
 
 [testenv:pypy]
@@ -33,7 +33,7 @@ commands = python -m pytest {posargs}
 
 
 [testenv:format]
-basepython = python3.12
+basepython = python3.13
 deps =
     black
     isort[toml]
@@ -44,7 +44,7 @@ commands =
 
 
 [testenv:coverage-report]
-basepython = python3.12
+basepython = python3.13
 deps = coverage[toml]
 skip_install = true
 commands =


### PR DESCRIPTION
Drops Python 3.9 (which reached end of life in October 2025) and adds support for Python 3.14.

The pytest-asyncio pin in tox.ini also gets bumped from 0.11.0 to the 0.24 series, since the old pin doesn't support Python 3.14. The newer version still exposes the event_loop fixture used by tests/conftest.py so no test changes are needed.