### PR TITLE
fix: use _location instead of location in XMLParseError raised by visit_import

### DIFF
--- a/src/zeep/xsd/visitor.py
+++ b/src/zeep/xsd/visitor.py
@@ -195,7 +195,7 @@ class SchemaVisitor:
             raise XMLParseError(
                 "The attribute 'namespace' must be existent if the "
                 "importing schema has no target namespace.",
-                filename=self.document.location,
+                filename=self.document._location,
                 sourceline=node.sourceline,
             )
 


### PR DESCRIPTION
In visit_import, the XMLParseError raised when a no-namespace schema tries to import without an explicit namespace attribute passes self.document.location as the filename. SchemaDocument stores the path in _location though, so hitting this branch raises an AttributeError instead of the intended error, hiding the real problem.

One-character fix. I ran into this debugging a WCF WSDL that triggered the exact code path; without this patch the exception handler itself crashes before reporting anything useful.

The branch is only reached with unusual XSD patterns (a schema with no targetNamespace importing another no-namespace schema), which is probably why it went unnoticed.