### PR TITLE
fix: decode negative xsd:duration as seconds, not days

### DIFF
--- a/src/zeep/xsd/types/builtins.py
+++ b/src/zeep/xsd/types/builtins.py
@@ -136,7 +136,7 @@ class Duration(BuiltinType):
         if value.startswith("PT-"):
             value = value.replace("PT-", "PT")
             result = isodate.parse_duration(value)
-            return datetime.timedelta(0 - result.total_seconds())
+            return datetime.timedelta(seconds=0 - result.total_seconds())
         else:
             return isodate.parse_duration(value)
 

--- a/tests/test_xsd_builtins.py
+++ b/tests/test_xsd_builtins.py
@@ -153,6 +153,11 @@ class TestDuration:
         value = "\r  \nP0Y1347M0D\t "
         assert instance.pythonvalue(value) == expected
 
+    def test_pythonvalue_negative(self):
+        instance = builtins.Duration()
+        assert instance.pythonvalue("PT-30S") == datetime.timedelta(seconds=-30)
+        assert instance.pythonvalue("PT-1M") == datetime.timedelta(minutes=-1)
+
 
 class TestDateTime:
     def test_xmlvalue(self):


### PR DESCRIPTION
## Summary

`Duration.pythonvalue` decoded negative `xsd:duration` values with the wrong unit. The `PT-` workaround passed `result.total_seconds()` into `timedelta`'s positional `days` argument, so `PT-30S` decoded as -30 days instead of -30 seconds (off by 86400). This passes the value as `seconds=`.

Added a regression test in `tests/test_xsd_builtins.py` (`TestDuration.test_pythonvalue_negative`). Full suite passes (473 passed, 17 pre-existing network skips).

Closes #1492.
