### PR TITLE
Make sure datetime is a datetime

### DIFF
--- a/src/zeep/xsd/types/builtins.py
+++ b/src/zeep/xsd/types/builtins.py
@@ -149,6 +149,12 @@ class DateTime(BuiltinType):
         if isinstance(value, str):
             return value
 
+        if not isinstance(value, datetime.datetime):
+            # The value passed in could be either a datetime or a date
+            # if it's a date merge in datetime.time.min - `datetime.time(0, 0)`
+            # to make it a datetime
+            value = datetime.datetime.combine(value, datetime.time.min)
+
         return value.isoformat().replace("+00:00", "Z")
 
     @treat_whitespace("collapse")
@@ -188,6 +194,7 @@ class Date(BuiltinType):
     def xmlvalue(self, value):
         if isinstance(value, str):
             return value
+
         return value.strftime("%Y-%m-%d")
 
     @treat_whitespace("collapse")

--- a/tests/test_xsd_builtins.py
+++ b/tests/test_xsd_builtins.py
@@ -157,6 +157,10 @@ class TestDuration:
 class TestDateTime:
     def test_xmlvalue(self):
         instance = builtins.DateTime()
+        value = datetime.date(2016, 3, 4)
+        assert instance.xmlvalue(value) == "2016-03-04T00:00:00"
+
+        instance = builtins.DateTime()
         value = datetime.datetime(2016, 3, 4, 21, 14, 42)
         assert instance.xmlvalue(value) == "2016-03-04T21:14:42"
 


### PR DESCRIPTION
In https://github.com/mvantellingen/python-zeep/pull/1443, all the special case code for pytz was removed since pytz isn't used anymore. Unfortunately it removed a case in builtins.DateTime where it would add in the time values if they were missing.

This causes issues if a user passes in a date to a datetime field as it get's sent up as an iso format date, not datetime and the receiving server may reject it.

This is a critical bug, and blocking updating to 4.3.3 with the security fix.