### PR TITLE
fix: renderpath for type-extensions

### DIFF
--- a/src/zeep/xsd/types/complex.py
+++ b/src/zeep/xsd/types/complex.py
@@ -279,6 +279,7 @@ class ComplexType(AnyType):
             and not isinstance(value, (list, dict, CompoundValue))
         ):
             element = self.elements_nested[0][1]
+            child_path = render_path + [element.name]
             element.type.render(node, value, None, child_path)
             return
 

--- a/tests/test_xsd_complex_types.py
+++ b/tests/test_xsd_complex_types.py
@@ -365,6 +365,39 @@ def test_xml_simple_content_nil():
     assert obj._value_1 is None
 
 
+def test_xml_simple_content_extension_render():
+    schema = xsd.Schema(
+        load_xml(
+            """
+    <?xml version="1.0"?>
+    <schema xmlns="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://tests.python-zeep.org/"
+            targetNamespace="http://tests.python-zeep.org/"
+            elementFormDefault="qualified">
+      <element name="container">
+        <complexType>
+          <simpleContent>
+            <extension base="string" />
+          </simpleContent>
+        </complexType>
+      </element>
+    </schema>
+    """
+        )
+    )
+    schema.set_ns_prefix("tns", "http://tests.python-zeep.org/")
+    container_elm = schema.get_element("tns:container")
+
+    result = render_node(container_elm, "my-test-value")
+
+    expected = """
+      <document>
+        <ns0:container xmlns:ns0="http://tests.python-zeep.org/">my-test-value</ns0:container>
+      </document>
+    """
+    assert_nodes_equal(result, expected)
+
+
 def test_ignore_sequence_order():
     schema_doc = load_xml(
         b"""

--- a/tests/test_xsd_complex_types.py
+++ b/tests/test_xsd_complex_types.py
@@ -358,7 +358,6 @@ def test_xml_simple_content_nil():
         <ns0:container xmlns:ns0="http://tests.python-zeep.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
       </document>
     """
-    result = render_node(container_elm, obj)
     assert_nodes_equal(result, expected)
 
     obj = container_elm.parse(result[0], schema)


### PR DESCRIPTION
The `child_path` variable can still be set from the attribute loop above, but then it has the wrong value. Without any attributes it is unset and causes an UnboundLocalError. Set it always to a proper value.

Fixes: 0c8a3fc4f9a8 ("Add support to pass base-types to type extensions")